### PR TITLE
refactor: Store access token in memory

### DIFF
--- a/docs/content/2.configuration/1.tokens.md
+++ b/docs/content/2.configuration/1.tokens.md
@@ -12,7 +12,6 @@ The algorithm used is `HS256` with symetric encryption, options can be set via `
 accessToken: {
     jwtSecret: "", // Required
     maxAge: 15 * 60, // The access token is valid for 15 minutes
-    cookieName: "auth_access_token"
 },
 
 refreshToken: {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "bcryptjs": "^2.4.3",
     "defu": "^6.1.3",
     "jose": "^5.1.0",
-    "js-cookie": "^3.0.5",
     "mustache": "^4.2.0",
     "uuid": "^9.0.1",
     "zod": "^3.22.4"
@@ -55,7 +54,6 @@
     "@nuxt/schema": "^3.8.1",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@types/bcryptjs": "^2.4.6",
-    "@types/js-cookie": "^3.0.6",
     "@types/mustache": "^4.2.5",
     "@types/uuid": "^9.0.7",
     "changelogen": "^0.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ dependencies:
   jose:
     specifier: ^5.1.0
     version: 5.1.1
-  js-cookie:
-    specifier: ^3.0.5
-    version: 3.0.5
   mustache:
     specifier: ^4.2.0
     version: 4.2.0
@@ -49,9 +46,6 @@ devDependencies:
   '@types/bcryptjs':
     specifier: ^2.4.6
     version: 2.4.6
-  '@types/js-cookie':
-    specifier: ^3.0.6
-    version: 3.0.6
   '@types/mustache':
     specifier: ^4.2.5
     version: 4.2.5
@@ -1930,10 +1924,6 @@ packages:
     resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
     dependencies:
       '@types/node': 20.9.5
-    dev: true
-
-  /@types/js-cookie@3.0.6:
-    resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
     dev: true
 
   /@types/json-schema@7.0.15:
@@ -4799,11 +4789,6 @@ packages:
 
   /jose@5.1.1:
     resolution: {integrity: sha512-bfB+lNxowY49LfrBO0ITUn93JbUhxUN8I11K6oI5hJu/G6PO6fEUddVLjqdD0cQ9SXIHWXuWh7eJYwZF7Z0N/g==}
-    dev: false
-
-  /js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
     dev: false
 
   /js-tokens@4.0.0:

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import {
   defineNuxtModule,
   addPlugin,
   createResolver,
-  addImportsDir,
+  addImports,
   addServerHandler,
   addTemplate,
   logger,
@@ -174,9 +174,21 @@ export default defineNuxtModule<ModuleOptions>({
     addPlugin(resolve(runtimeDir, 'plugins/provider'), { append: true })
     addPlugin(resolve(runtimeDir, 'plugins/flow'), { append: true })
 
-    // Add composables directory
-    const composables = resolve(runtimeDir, 'composables')
-    addImportsDir(composables)
+    // Add composables
+    addImports([
+      {
+        name: 'useAuth',
+        from: resolve(runtimeDir, 'composables/useAuth')
+      },
+      {
+        name: 'useAuthFetch',
+        from: resolve(runtimeDir, 'composables/useAuthFetch')
+      },
+      {
+        name: 'useAuthSession',
+        from: resolve(runtimeDir, 'composables/useAuthSession')
+      }
+    ])
 
     // Add server utils
     nuxt.options.nitro = defu(

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,7 +35,6 @@ export default defineNuxtModule<ModuleOptions>({
     baseUrl: '',
 
     accessToken: {
-      cookieName: 'auth_access_token',
       jwtSecret: '',
       maxAge: 15 * 60
     },
@@ -147,7 +146,6 @@ export default defineNuxtModule<ModuleOptions>({
 
       public: {
         auth: {
-          accessTokenCookieName: options.accessToken.cookieName,
           baseUrl: options.baseUrl,
           enableGlobalAuthMiddleware: options.enableGlobalAuthMiddleware,
           loggedInFlagName: options.loggedInFlagName,

--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -17,7 +17,6 @@ import {
 type useFetchReturn<T> = Promise<AsyncData<T | null, FetchError<H3Error> | null>>;
 
 export function useAuth () {
-  const { user } = useAuthSession()
   const publicConfig = useRuntimeConfig().public.auth as PublicConfig
 
   /**
@@ -67,6 +66,7 @@ export function useAuth () {
    * Fetch active user, usefull to update `user` state
    */
   async function fetchUser () {
+    const { user } = useAuthSession()
     try {
       const { $auth } = useNuxtApp()
       const data = await $auth.fetch('/api/auth/me')
@@ -88,6 +88,7 @@ export function useAuth () {
 
   async function _onLogin () {
     await fetchUser()
+    const { user } = useAuthSession()
     if (user.value === null) { return }
     const route = useRoute()
     const { callHook } = useNuxtApp()
@@ -99,6 +100,7 @@ export function useAuth () {
   }
 
   async function _onLogout () {
+    const { user } = useAuthSession()
     if (user.value === null) { return }
     const { callHook } = useNuxtApp()
     await callHook('auth:loggedIn', false)

--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -36,7 +36,8 @@ export function useAuth () {
     })
 
     if (!res.error.value && res.data.value) {
-      await _onLogin(res.data.value.access_token)
+      _accessToken.set(res.data.value.access_token)
+      await _onLogin()
     }
     return res
   }
@@ -45,18 +46,18 @@ export function useAuth () {
    * Login via oauth provider
    */
   function loginWithProvider (provider: Provider) {
-    if (process.client) {
-      const route = useRoute()
+    if (process.server) { return }
 
-      // The protected page the user has visited before redirect to login page
-      const returnToPath = route.query.redirect?.toString()
+    const route = useRoute()
 
-      let redirectUrl = resolveURL('/api/auth/login', provider)
+    // The protected page the user has visited before redirect to login page
+    const returnToPath = route.query.redirect?.toString()
 
-      redirectUrl = withQuery(redirectUrl, { redirect: returnToPath })
+    let redirectUrl = resolveURL('/api/auth/login', provider)
 
-      window.location.replace(redirectUrl)
-    }
+    redirectUrl = withQuery(redirectUrl, { redirect: returnToPath })
+
+    window.location.replace(redirectUrl)
   }
 
   /**
@@ -82,8 +83,7 @@ export function useAuth () {
     }).finally(_onLogout)
   }
 
-  async function _onLogin (accessToken: string) {
-    _accessToken.set(accessToken)
+  async function _onLogin () {
     await fetchUser()
     if (user.value === null) { return }
     const route = useRoute()
@@ -175,7 +175,6 @@ export function useAuth () {
     resetPassword,
     requestEmailVerify,
     changePassword,
-    _onLogout,
-    _onLogin
+    _onLogout
   }
 }

--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -3,6 +3,7 @@ import type { FetchError } from 'ofetch'
 import type { H3Error } from 'h3'
 import type { AsyncData } from '#app'
 import type { Provider, PublicConfig, Response } from '../types'
+import { useAuthToken } from './useAuthToken'
 import {
   useRuntimeConfig,
   useRoute,
@@ -18,7 +19,6 @@ type useFetchReturn<T> = Promise<AsyncData<T | null, FetchError<H3Error> | null>
 export function useAuth () {
   const { user } = useAuthSession()
   const publicConfig = useRuntimeConfig().public.auth as PublicConfig
-  const { _accessToken, _loggedIn } = useAuthSession()
 
   /**
    * Login with email/password
@@ -36,7 +36,10 @@ export function useAuth () {
     })
 
     if (!res.error.value && res.data.value) {
-      _accessToken.set(res.data.value.access_token)
+      useAuthToken().value = {
+        access_token: res.data.value.access_token,
+        expires: new Date().getTime() + res.data.value.expires_in * 1000
+      }
       await _onLogin()
     }
     return res
@@ -90,7 +93,7 @@ export function useAuth () {
     const { callHook } = useNuxtApp()
     const returnToPath = route.query.redirect?.toString()
     const redirectTo = returnToPath ?? publicConfig.redirect.home
-    _loggedIn.set(true)
+    useAuthSession()._loggedIn.set(true)
     await callHook('auth:loggedIn', true)
     await navigateTo(redirectTo)
   }
@@ -100,8 +103,8 @@ export function useAuth () {
     const { callHook } = useNuxtApp()
     await callHook('auth:loggedIn', false)
     user.value = null
-    _accessToken.clear()
-    _loggedIn.set(false)
+    useAuthToken().value = null
+    useAuthSession()._loggedIn.set(false)
     clearNuxtData()
     await navigateTo(publicConfig.redirect.logout)
   }

--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -26,20 +26,19 @@ export function useAuth () {
   async function login (credentials: {
     email: string;
     password: string;
-  }): useFetchReturn<{ accessToken: string }> {
-    return await useFetch('/api/auth/login', {
+  }): useFetchReturn<{ access_token: string, expires_in:number }> {
+    const res = await useFetch('/api/auth/login', {
       method: 'POST',
       body: {
         email: credentials.email,
         password: credentials.password
       }
-    }).then(async (res) => {
-      if (!res.error.value && res.data.value) {
-        await _onLogin(res.data.value.accessToken)
-      }
-
-      return res
     })
+
+    if (!res.error.value && res.data.value) {
+      await _onLogin(res.data.value.access_token)
+    }
+    return res
   }
 
   /**

--- a/src/runtime/composables/useAuthSession.ts
+++ b/src/runtime/composables/useAuthSession.ts
@@ -54,7 +54,6 @@ export function useAuthSession () {
       })
       .then((res) => {
         const setCookie = res.headers.get('set-cookie') ?? ''
-
         const cookies = splitCookiesString(setCookie)
 
         for (const cookie of cookies) {
@@ -68,11 +67,9 @@ export function useAuthSession () {
           }
           _loggedIn.set(true)
         }
-        isRefreshOn.value = false
         return res
       })
       .catch(async () => {
-        isRefreshOn.value = false
         accessToken.value = null
         _refreshToken.clear()
         _loggedIn.set(false)
@@ -80,6 +77,8 @@ export function useAuthSession () {
         if (process.client) {
           await navigateTo(publicConfig.redirect.logout)
         }
+      }).finally(() => {
+        isRefreshOn.value = false
       })
   }
 

--- a/src/runtime/composables/useAuthSession.ts
+++ b/src/runtime/composables/useAuthSession.ts
@@ -95,7 +95,7 @@ export function useAuthSession () {
     const headers = useRequestHeaders(['cookie', 'user-agent'])
 
     await $fetch
-      .raw<{ accessToken: string }>('/api/auth/session/refresh', {
+      .raw<{ access_token: string, expires_in:number }>('/api/auth/session/refresh', {
         method: 'POST',
         headers
       })
@@ -109,7 +109,7 @@ export function useAuthSession () {
         }
 
         if (res._data) {
-          _accessToken.set(res._data.accessToken)
+          _accessToken.set(res._data.access_token)
           _loggedIn.set(true)
         }
         isRefreshOn.value = false

--- a/src/runtime/composables/useAuthToken.ts
+++ b/src/runtime/composables/useAuthToken.ts
@@ -20,6 +20,11 @@ function memoryStorage () {
 
 const memory = memoryStorage()
 
+/**
+ * This composable permits the storage of access token in memory
+ * On SSR, it's stored with `useState`. On SPA its stored in a scoped memory.
+ * Given that `useState` is accessible on global context, it's cleared on SPA.
+ */
 export function useAuthToken () {
   const state = useState<TokenStore | null>('auth-token', () => null)
 

--- a/src/runtime/composables/useAuthToken.ts
+++ b/src/runtime/composables/useAuthToken.ts
@@ -1,0 +1,56 @@
+import { useState } from '#imports'
+
+interface TokenStore {
+  access_token: string;
+  expires: number;
+}
+
+function memoryStorage () {
+  let store: TokenStore | null = null
+
+  return {
+    get value () {
+      return store
+    },
+    set value (data: TokenStore | null) {
+      if (process.client) { store = data }
+    }
+  }
+}
+
+const memory = memoryStorage()
+
+export function useAuthToken () {
+  const state = useState<TokenStore | null>('auth-token', () => null)
+
+  if (process.client && state.value) {
+    memory.value = { ...state.value }
+    state.value = null
+  }
+
+  return {
+    get value () {
+      if (process.client) {
+        return memory.value
+      }
+      return state.value
+    },
+
+    set value (data: TokenStore | null) {
+      if (process.client) {
+        memory.value = data
+      } else {
+        state.value = data
+      }
+    },
+
+    get expired () {
+      if (this.value) {
+        const msRefreshBeforeExpires = 3000
+        const expires = this.value.expires - msRefreshBeforeExpires
+        return expires < Date.now()
+      }
+      return false
+    }
+  }
+}

--- a/src/runtime/plugins/provider.ts
+++ b/src/runtime/plugins/provider.ts
@@ -1,30 +1,11 @@
 import { defu } from 'defu'
 import {
   defineNuxtPlugin,
-  useAuth,
   useAuthSession,
-  useRequestHeaders,
-  useRuntimeConfig
+  useRequestHeaders
 } from '#imports'
 
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.hook('app:mounted', () => {
-    addEventListener('storage', (event) => {
-      const loggedInName = useRuntimeConfig().public.auth.loggedInFlagName
-
-      if (event.key === loggedInName) {
-        if (event.oldValue === 'true' && event.newValue === 'false') {
-          useAuth()._onLogout()
-        } else if (event.oldValue === 'false' && event.newValue === 'true') {
-          const accessToken = useAuthSession()._accessToken.get()
-          if (accessToken) {
-            useAuth()._onLogin(accessToken)
-          }
-        }
-      }
-    })
-  })
-
+export default defineNuxtPlugin(() => {
   const userAgent = useRequestHeaders(['user-agent'])['user-agent']
 
   const fetch = $fetch.create({

--- a/src/runtime/plugins/provider.ts
+++ b/src/runtime/plugins/provider.ts
@@ -8,6 +8,9 @@ import {
 export default defineNuxtPlugin(() => {
   const userAgent = useRequestHeaders(['user-agent'])['user-agent']
 
+  /**
+   * A $fetch instance with auto authorization handler
+   */
   const fetch = $fetch.create({
     async onRequest ({ options }) {
       const { getAccessToken } = useAuthSession()

--- a/src/runtime/server/api/auth/login/index.post.ts
+++ b/src/runtime/server/api/auth/login/index.post.ts
@@ -49,7 +49,7 @@ export default defineEventHandler(async (event) => {
     const sessionId = payload.id
     const accessToken = await createAccessToken(event, user, sessionId)
 
-    return { accessToken }
+    return accessToken
   } catch (error) {
     await handleError(error)
   }

--- a/src/runtime/server/api/auth/session/refresh.post.ts
+++ b/src/runtime/server/api/auth/session/refresh.post.ts
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
 
     const accessToken = await createAccessToken(event, user, sessionId)
 
-    return { accessToken }
+    return accessToken
   } catch (error) {
     deleteRefreshTokenCookie(event)
 

--- a/src/runtime/server/utils/token/accessToken.ts
+++ b/src/runtime/server/utils/token/accessToken.ts
@@ -32,7 +32,10 @@ export async function createAccessToken (event: H3Event, user: User, sessionId: 
     config.private.accessToken.maxAge!
   )
 
-  return accessToken
+  return {
+    access_token: accessToken,
+    expires_in: config.private.accessToken.maxAge
+  }
 }
 
 /**

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -65,7 +65,6 @@ interface MailResendProvider {
 
 export type PrivateConfig = {
   accessToken: {
-    cookieName?: string;
     jwtSecret: string;
     maxAge?: number;
     customClaims?: Record<string, any>;

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -126,4 +126,4 @@ export type PublicConfig = {
   };
 };
 
-interface Response { status: string }
+export interface Response { status: string }


### PR DESCRIPTION
This PR introduces a change on access token storage.

Previously the token is stored on a non http-only cookie in order to permit the read on client-side and avoid extra refresh calls.

Now the token is stored in a scoped browser memory. This permits more security against XSS attacks at the expense of extra refresh calls on window load/reload.