### PR TITLE
fix(registration): inform user when account not verified

### DIFF
--- a/docs/content/3.usage/1.composables.md
+++ b/docs/content/3.usage/1.composables.md
@@ -31,6 +31,7 @@ Some specific error messages are thrown by these methods.
   - wrong-credentials
 - `register`
   - email-used-with-{provider}
+  - account-not-verified
 - `changePassword`
   - wrong-password
 - `resetPassword`

--- a/src/runtime/server/api/auth/register.post.ts
+++ b/src/runtime/server/api/auth/register.post.ts
@@ -21,6 +21,9 @@ export default defineEventHandler(async (event) => {
     const user = await findUser(event, { email })
 
     if (user) {
+      if (!user.verified && config.private.registration.requireEmailVerification) {
+        throw new Error('account-not-verified')
+      }
       throw new Error(`email-used-with-${user.provider}`)
     }
 


### PR DESCRIPTION
Previously when attempting registration with the same non-verified email address the server returns `email-used-with-{provider}` error message. This PR add `account-not-verified` error which indicates that verification is needed.