### PR TITLE
refactor!: change server error messages

### DIFF
--- a/src/runtime/server/api/auth/avatar.get.ts
+++ b/src/runtime/server/api/auth/avatar.get.ts
@@ -1,34 +1,24 @@
-import { defineEventHandler, getQuery, setResponseHeaders, createError } from 'h3'
+import { defineEventHandler, getValidatedQuery, setResponseHeaders } from 'h3'
+import { z } from 'zod'
 
-export default defineEventHandler((event) => {
-  const query = getQuery<{
-    name: string
-    color: string
-    background: string
-  }>(event)
+export default defineEventHandler(async (event) => {
+  const schema = z.object({
+    name: z.string().min(1),
+    color: z.string().regex(/^([a-f0-9]{6}|[a-f0-9]{3})$/).optional(),
+    background: z.string().regex(/^([a-f0-9]{6}|[a-f0-9]{3})$/).optional(),
+  })
 
-  query.name ||= ''
+  const query = await getValidatedQuery(event, schema.parse)
+
   query.background ||= 'f0e9e9'
   query.color ||= '8b5d5d'
-
-  const validateColor = (color: string) => {
-    const valid = /^[A-F0-9]{6}|[A-F0-9]{3}$/i.test(color)
-    if (!valid) {
-      throw createError({
-        statusCode: 422,
-        message: 'Color should be in format rrggbb or rgb',
-      })
-    }
-  }
-
-  validateColor(query.color)
-  validateColor(query.background)
 
   setResponseHeaders(event, {
     'Content-Type': 'image/svg+xml',
     'Cache-Control': 'public, max-age=2592000, immutable',
   })
 
+  // TODO: create utility function
   return `
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64px" height="64px" viewBox="0 0 64 64" version="1.1">
         <rect fill="#${query.background}" cx="32" width="64" height="64" cy="32" r="32"/>

--- a/src/runtime/server/api/auth/email/request.post.ts
+++ b/src/runtime/server/api/auth/email/request.post.ts
@@ -1,14 +1,15 @@
 import { defineEventHandler, readValidatedBody } from 'h3'
 import { resolveURL, withQuery } from 'ufo'
 import { z } from 'zod'
-import { mustache, getConfig, sendMail, createEmailVerifyToken, handleError } from '../../../utils'
+import { mustache, getConfig, sendMail, createEmailVerifyToken, handleError, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   try {
+    // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.emailVerify) {
-      throw new Error('Please make sure to set emailVerify redirect path')
+      throw createCustomError(500, 'Please make sure to set emailVerify redirect path')
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/email/request.post.ts
+++ b/src/runtime/server/api/auth/email/request.post.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
   try {
     // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.emailVerify) {
-      throw createCustomError(500, 'Please make sure to set emailVerify redirect path')
+      throw createCustomError(500, 'Something went wrong')
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/email/request.post.ts
+++ b/src/runtime/server/api/auth/email/request.post.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, readBody } from 'h3'
+import { defineEventHandler, readValidatedBody } from 'h3'
 import { resolveURL, withQuery } from 'ufo'
 import { z } from 'zod'
 import { mustache, getConfig, sendMail, createEmailVerifyToken, handleError } from '../../../utils'
@@ -11,13 +11,11 @@ export default defineEventHandler(async (event) => {
       throw new Error('Please make sure to set emailVerify redirect path')
     }
 
-    const { email } = await readBody(event)
-
     const schema = z.object({
       email: z.string().email(),
     })
 
-    schema.parse({ email })
+    const { email } = await readValidatedBody(event, schema.parse)
 
     const user = await event.context._authAdapter.user.findByEmail(email)
 

--- a/src/runtime/server/api/auth/email/verify.get.ts
+++ b/src/runtime/server/api/auth/email/verify.get.ts
@@ -1,6 +1,8 @@
-import { defineEventHandler, getQuery, sendRedirect } from 'h3'
+import { defineEventHandler, getValidatedQuery, sendRedirect } from 'h3'
 import { z } from 'zod'
 import { getConfig, verifyEmailVerifyToken, handleError } from '../../../utils'
+
+// TODO: update docs `token-not-found` message removed
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
@@ -10,17 +12,11 @@ export default defineEventHandler(async (event) => {
       throw new Error('Please make sure to set emailVerify redirect path')
     }
 
-    const token = getQuery(event).token?.toString()
-
     const schema = z.object({
-      token: z.string(),
+      token: z.string().min(1),
     })
 
-    schema.parse({ token })
-
-    if (!token) {
-      throw new Error('token-not-found')
-    }
+    const { token } = await getValidatedQuery(event, schema.parse)
 
     const payload = await verifyEmailVerifyToken(token)
 

--- a/src/runtime/server/api/auth/email/verify.get.ts
+++ b/src/runtime/server/api/auth/email/verify.get.ts
@@ -2,15 +2,13 @@ import { defineEventHandler, getValidatedQuery, sendRedirect } from 'h3'
 import { z } from 'zod'
 import { getConfig, verifyEmailVerifyToken, handleError, createCustomError } from '../../../utils'
 
-// TODO: update docs `token-not-found` message removed
-
 export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   try {
     // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.emailVerify) {
-      throw createCustomError(500, 'Please make sure to set emailVerify redirect path')
+      throw createCustomError(500, 'Something went wrong')
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/email/verify.get.ts
+++ b/src/runtime/server/api/auth/email/verify.get.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, getValidatedQuery, sendRedirect } from 'h3'
 import { z } from 'zod'
-import { getConfig, verifyEmailVerifyToken, handleError } from '../../../utils'
+import { getConfig, verifyEmailVerifyToken, handleError, createCustomError } from '../../../utils'
 
 // TODO: update docs `token-not-found` message removed
 
@@ -8,8 +8,9 @@ export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   try {
+    // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.emailVerify) {
-      throw new Error('Please make sure to set emailVerify redirect path')
+      throw createCustomError(500, 'Please make sure to set emailVerify redirect path')
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/login/[provider].get.ts
+++ b/src/runtime/server/api/auth/login/[provider].get.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
 
   // TODO: endpoint should not exist in the first place
   if (!providers.length) {
-    throw createCustomError(500, 'oauth-not-configured')
+    throw createCustomError(500, 'Something went wrong')
   }
 
   const pSchema = z.object({

--- a/src/runtime/server/api/auth/login/[provider].get.ts
+++ b/src/runtime/server/api/auth/login/[provider].get.ts
@@ -1,21 +1,33 @@
-import { defineEventHandler, sendRedirect, getQuery } from 'h3'
+import { defineEventHandler, sendRedirect, getValidatedQuery, getValidatedRouterParams } from 'h3'
 import { resolveURL, withQuery } from 'ufo'
+import { z } from 'zod'
 import { getConfig, handleError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
-  const provider = event.context.params!.provider
 
-  const oauthProvider = config.private.oauth?.[provider]
+  const providers = config.private.oauth ? Object.keys(config.private.oauth) : []
 
-  if (!oauthProvider) {
+  if (!providers.length) {
     throw new Error('oauth-not-configured')
   }
 
+  const pSchema = z.object({
+    provider: z.custom<string>(value => providers.includes(value)),
+  })
+
+  const { provider } = await getValidatedRouterParams(event, pSchema.parse)
+
+  const qSchema = z.object({
+    redirect: z.string().startsWith('/').optional(),
+  })
+
   // The protected page the user has visited before redirect to login page
-  const returnToPath = getQuery(event)?.redirect
+  const { redirect: returnToPath } = await getValidatedQuery(event, qSchema.parse)
 
   try {
+    const oauthProvider = config.private.oauth![provider]
+
     const redirectUri = resolveURL(config.public.baseUrl, '/api/auth/login', provider, 'callback')
 
     const authorizationUrl = withQuery(

--- a/src/runtime/server/api/auth/login/[provider].get.ts
+++ b/src/runtime/server/api/auth/login/[provider].get.ts
@@ -1,15 +1,16 @@
 import { defineEventHandler, sendRedirect, getValidatedQuery, getValidatedRouterParams } from 'h3'
 import { resolveURL, withQuery } from 'ufo'
 import { z } from 'zod'
-import { getConfig, handleError } from '../../../utils'
+import { getConfig, handleError, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   const providers = config.private.oauth ? Object.keys(config.private.oauth) : []
 
+  // TODO: endpoint should not exist in the first place
   if (!providers.length) {
-    throw new Error('oauth-not-configured')
+    throw createCustomError(500, 'oauth-not-configured')
   }
 
   const pSchema = z.object({

--- a/src/runtime/server/api/auth/login/[provider]/callback.get.ts
+++ b/src/runtime/server/api/auth/login/[provider]/callback.get.ts
@@ -10,14 +10,14 @@ export default defineEventHandler(async (event) => {
   try {
     // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.callback) {
-      throw createCustomError(500, 'Please make sure to set callback redirect path')
+      throw createCustomError(500, 'Something went wrong')
     }
 
     const providers = config.private.oauth ? Object.keys(config.private.oauth) : []
 
     // TODO: endpoint should not exist in the first place
     if (!providers.length) {
-      throw createCustomError(500, 'oauth-not-configured')
+      throw createCustomError(500, 'Something went wrong')
     }
 
     const pSchema = z.object({
@@ -66,11 +66,11 @@ export default defineEventHandler(async (event) => {
     })
 
     if (!userInfo.name) {
-      throw createCustomError(400, 'name-not-accessible')
+      throw createCustomError(400, 'Oauth name not accessible')
     }
 
     if (!userInfo.email) {
-      throw createCustomError(400, 'email-not-accessible')
+      throw createCustomError(400, 'Oauth email not accessible')
     }
 
     const user = await event.context._authAdapter.user.findByEmail(userInfo.email)
@@ -79,16 +79,16 @@ export default defineEventHandler(async (event) => {
 
     if (user) {
       if (user.provider !== provider) {
-        throw createCustomError(403, `email-used-with-${user.provider}`)
+        throw createCustomError(403, 'Email already used')
       }
 
       if (user.suspended) {
-        throw createCustomError(403, 'account-suspended')
+        throw createCustomError(403, 'Account suspended')
       }
     }
     else {
       if (config.private.registration.enabled === false) {
-        throw createCustomError(500, 'registration-disabled')
+        throw createCustomError(500, 'Registration disabled')
       }
 
       const pictureKey = Object.keys(userInfo).find(el =>

--- a/src/runtime/server/api/auth/login/index.post.ts
+++ b/src/runtime/server/api/auth/login/index.post.ts
@@ -21,18 +21,18 @@ export default defineEventHandler(async (event) => {
       || !user.password
       || !compareSync(password, user.password)
     ) {
-      throw createCustomError(401, 'wrong-credentials')
+      throw createCustomError(401, 'Wrong credentials')
     }
 
     if (
       !user.verified
       && config.private.registration.requireEmailVerification
     ) {
-      throw createCustomError(403, 'account-not-verified')
+      throw createCustomError(403, 'Account not verified')
     }
 
     if (user.suspended) {
-      throw createCustomError(403, 'account-suspended')
+      throw createCustomError(403, 'Account suspended')
     }
 
     const payload = await createRefreshToken(event, user.id)

--- a/src/runtime/server/api/auth/login/index.post.ts
+++ b/src/runtime/server/api/auth/login/index.post.ts
@@ -1,4 +1,4 @@
-import { readBody, defineEventHandler } from 'h3'
+import { readValidatedBody, defineEventHandler } from 'h3'
 import { z } from 'zod'
 import { getConfig, createRefreshToken, setRefreshTokenCookie, createAccessToken, compareSync, handleError, signRefreshToken } from '../../../utils'
 
@@ -6,14 +6,12 @@ export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   try {
-    const { email, password } = await readBody(event)
-
     const schema = z.object({
       email: z.string().email(),
-      password: z.string(),
+      password: z.string().min(1),
     })
 
-    schema.parse({ email, password })
+    const { email, password } = await readValidatedBody(event, schema.parse)
 
     const user = await event.context._authAdapter.user.findByEmail(email)
 

--- a/src/runtime/server/api/auth/login/index.post.ts
+++ b/src/runtime/server/api/auth/login/index.post.ts
@@ -1,6 +1,6 @@
 import { readValidatedBody, defineEventHandler } from 'h3'
 import { z } from 'zod'
-import { getConfig, createRefreshToken, setRefreshTokenCookie, createAccessToken, compareSync, handleError, signRefreshToken } from '../../../utils'
+import { getConfig, createRefreshToken, setRefreshTokenCookie, createAccessToken, compareSync, handleError, signRefreshToken, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
@@ -21,18 +21,18 @@ export default defineEventHandler(async (event) => {
       || !user.password
       || !compareSync(password, user.password)
     ) {
-      throw new Error('wrong-credentials')
+      throw createCustomError(401, 'wrong-credentials')
     }
 
     if (
       !user.verified
       && config.private.registration.requireEmailVerification
     ) {
-      throw new Error('account-not-verified')
+      throw createCustomError(403, 'account-not-verified')
     }
 
     if (user.suspended) {
-      throw new Error('account-suspended')
+      throw createCustomError(403, 'account-suspended')
     }
 
     const payload = await createRefreshToken(event, user.id)

--- a/src/runtime/server/api/auth/me.get.ts
+++ b/src/runtime/server/api/auth/me.get.ts
@@ -1,18 +1,18 @@
 import { defineEventHandler } from 'h3'
-import { handleError } from '../../utils'
+import { handleError, createUnauthorizedError } from '../../utils'
 
 export default defineEventHandler(async (event) => {
   try {
     const auth = event.context.auth
 
     if (!auth) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     const user = await event.context._authAdapter.user.findById(auth.userId)
 
     if (!user) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     const { password, ...sanitizedUser } = user

--- a/src/runtime/server/api/auth/password/change.put.ts
+++ b/src/runtime/server/api/auth/password/change.put.ts
@@ -28,7 +28,7 @@ export default defineEventHandler(async (event) => {
       || !user.password
       || !compareSync(currentPassword, user.password)
     ) {
-      throw createCustomError(401, 'wrong-password')
+      throw createCustomError(401, 'Wrong password')
     }
 
     const hashedPassword = hashSync(newPassword, 12)

--- a/src/runtime/server/api/auth/password/change.put.ts
+++ b/src/runtime/server/api/auth/password/change.put.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readValidatedBody } from 'h3'
 import { z } from 'zod'
-import { getConfig, hashSync, compareSync, handleError, createUnauthorizedError } from '../../../utils'
+import { getConfig, hashSync, compareSync, handleError, createUnauthorizedError, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
@@ -28,7 +28,7 @@ export default defineEventHandler(async (event) => {
       || !user.password
       || !compareSync(currentPassword, user.password)
     ) {
-      throw new Error('wrong-password')
+      throw createCustomError(401, 'wrong-password')
     }
 
     const hashedPassword = hashSync(newPassword, 12)

--- a/src/runtime/server/api/auth/password/change.put.ts
+++ b/src/runtime/server/api/auth/password/change.put.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readValidatedBody } from 'h3'
 import { z } from 'zod'
-import { getConfig, hashSync, compareSync, handleError } from '../../../utils'
+import { getConfig, hashSync, compareSync, handleError, createUnauthorizedError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     const auth = event.context.auth
 
     if (!auth) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/password/request.post.ts
+++ b/src/runtime/server/api/auth/password/request.post.ts
@@ -1,14 +1,15 @@
 import { defineEventHandler, readValidatedBody } from 'h3'
 import { resolveURL, withQuery } from 'ufo'
 import { z } from 'zod'
-import { mustache, getConfig, sendMail, createResetPasswordToken, handleError } from '../../../utils'
+import { mustache, getConfig, sendMail, createResetPasswordToken, handleError, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   try {
+    // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.passwordReset) {
-      throw new Error('Please make sure to set passwordReset redirect path')
+      throw createCustomError(500, 'Please make sure to set passwordReset redirect path')
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/password/request.post.ts
+++ b/src/runtime/server/api/auth/password/request.post.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
   try {
     // TODO: endpoint should not exist in the first place
     if (!config.public.redirect.passwordReset) {
-      throw createCustomError(500, 'Please make sure to set passwordReset redirect path')
+      throw createCustomError(500, 'Something went wrong')
     }
 
     const schema = z.object({

--- a/src/runtime/server/api/auth/password/request.post.ts
+++ b/src/runtime/server/api/auth/password/request.post.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, readBody } from 'h3'
+import { defineEventHandler, readValidatedBody } from 'h3'
 import { resolveURL, withQuery } from 'ufo'
 import { z } from 'zod'
 import { mustache, getConfig, sendMail, createResetPasswordToken, handleError } from '../../../utils'
@@ -11,13 +11,11 @@ export default defineEventHandler(async (event) => {
       throw new Error('Please make sure to set passwordReset redirect path')
     }
 
-    const { email } = await readBody(event)
-
     const schema = z.object({
       email: z.string().email(),
     })
 
-    schema.parse({ email })
+    const { email } = await readValidatedBody(event, schema.parse)
 
     const user = await event.context._authAdapter.user.findByEmail(email)
 

--- a/src/runtime/server/api/auth/password/reset.put.ts
+++ b/src/runtime/server/api/auth/password/reset.put.ts
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
     const user = await event.context._authAdapter.user.findById(payload.userId)
 
     if (!user?.requestedPasswordReset) {
-      throw createCustomError(403, 'reset-not-requested')
+      throw createCustomError(403, 'Password reset not requested')
     }
 
     const hashedPassword = hashSync(password, 12)

--- a/src/runtime/server/api/auth/password/reset.put.ts
+++ b/src/runtime/server/api/auth/password/reset.put.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readValidatedBody } from 'h3'
 import { z } from 'zod'
-import { getConfig, verifyResetPasswordToken, hashSync, handleError } from '../../../utils'
+import { getConfig, verifyResetPasswordToken, hashSync, handleError, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
     const user = await event.context._authAdapter.user.findById(payload.userId)
 
     if (!user?.requestedPasswordReset) {
-      throw new Error('reset-not-requested')
+      throw createCustomError(403, 'reset-not-requested')
     }
 
     const hashedPassword = hashSync(password, 12)

--- a/src/runtime/server/api/auth/register.post.ts
+++ b/src/runtime/server/api/auth/register.post.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readValidatedBody } from 'h3'
 import { z } from 'zod'
-import { getConfig, hashSync, handleError, generateAvatar } from '../../utils'
+import { getConfig, hashSync, handleError, generateAvatar, createCustomError } from '../../utils'
 
 export default defineEventHandler(async (event) => {
   const config = getConfig()
@@ -18,9 +18,9 @@ export default defineEventHandler(async (event) => {
 
     if (user) {
       if (!user.verified && config.private.registration.requireEmailVerification) {
-        throw new Error('account-not-verified')
+        throw createCustomError(403, 'account-not-verified')
       }
-      throw new Error(`email-used-with-${user.provider}`)
+      throw createCustomError(403, `email-used-with-${user.provider}`)
     }
 
     const hashedPassword = hashSync(password, 12)

--- a/src/runtime/server/api/auth/register.post.ts
+++ b/src/runtime/server/api/auth/register.post.ts
@@ -18,9 +18,9 @@ export default defineEventHandler(async (event) => {
 
     if (user) {
       if (!user.verified && config.private.registration.requireEmailVerification) {
-        throw createCustomError(403, 'account-not-verified')
+        throw createCustomError(403, 'Account not verified')
       }
-      throw createCustomError(403, `email-used-with-${user.provider}`)
+      throw createCustomError(403, 'Email already used')
     }
 
     const hashedPassword = hashSync(password, 12)

--- a/src/runtime/server/api/auth/session/index.get.ts
+++ b/src/runtime/server/api/auth/session/index.get.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3'
-import { handleError } from '../../../utils'
+import { handleError, createUnauthorizedError } from '../../../utils'
 import type { Session } from '../../../../types'
 
 export default defineEventHandler(async (event) => {
@@ -7,7 +7,7 @@ export default defineEventHandler(async (event) => {
     const auth = event.context.auth
 
     if (!auth) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     const refreshTokens = await event.context._authAdapter.refreshToken.findManyByUserId(auth.userId)

--- a/src/runtime/server/api/auth/session/refresh.post.ts
+++ b/src/runtime/server/api/auth/session/refresh.post.ts
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
     }
 
     if (user.suspended) {
-      throw createCustomError(403, 'account-suspended')
+      throw createCustomError(403, 'Account suspended')
     }
 
     const newRefreshToken = await updateRefreshToken(event, payload.id, user.id)

--- a/src/runtime/server/api/auth/session/refresh.post.ts
+++ b/src/runtime/server/api/auth/session/refresh.post.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3'
-import { createAccessToken, getRefreshTokenFromCookie, setRefreshTokenCookie, updateRefreshToken, verifyRefreshToken, deleteRefreshTokenCookie, handleError, createUnauthorizedError } from '../../../utils'
+import { createAccessToken, getRefreshTokenFromCookie, setRefreshTokenCookie, updateRefreshToken, verifyRefreshToken, deleteRefreshTokenCookie, handleError, createUnauthorizedError, createCustomError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
     }
 
     if (user.suspended) {
-      throw new Error('account-suspended')
+      throw createCustomError(403, 'account-suspended')
     }
 
     const newRefreshToken = await updateRefreshToken(event, payload.id, user.id)

--- a/src/runtime/server/api/auth/session/refresh.post.ts
+++ b/src/runtime/server/api/auth/session/refresh.post.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3'
-import { createAccessToken, getRefreshTokenFromCookie, setRefreshTokenCookie, updateRefreshToken, verifyRefreshToken, deleteRefreshTokenCookie, handleError } from '../../../utils'
+import { createAccessToken, getRefreshTokenFromCookie, setRefreshTokenCookie, updateRefreshToken, verifyRefreshToken, deleteRefreshTokenCookie, handleError, createUnauthorizedError } from '../../../utils'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     const user = await event.context._authAdapter.user.findById(payload.userId)
 
     if (!user) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     if (user.suspended) {

--- a/src/runtime/server/api/auth/session/revoke/[id].delete.ts
+++ b/src/runtime/server/api/auth/session/revoke/[id].delete.ts
@@ -1,13 +1,13 @@
 import { defineEventHandler, getValidatedRouterParams } from 'h3'
 import { z } from 'zod'
-import { handleError } from '../../../../utils'
+import { handleError, createUnauthorizedError } from '../../../../utils'
 
 export default defineEventHandler(async (event) => {
   try {
     const auth = event.context.auth
 
     if (!auth) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     const schema = z.object({
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
     const refreshTokenEntity = await event.context._authAdapter.refreshToken.findById(id)
 
     if (!refreshTokenEntity || refreshTokenEntity.userId !== auth.userId) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     await event.context._authAdapter.refreshToken.delete(id)

--- a/src/runtime/server/api/auth/session/revoke/[id].delete.ts
+++ b/src/runtime/server/api/auth/session/revoke/[id].delete.ts
@@ -1,22 +1,21 @@
-import { defineEventHandler } from 'h3'
+import { defineEventHandler, getValidatedRouterParams } from 'h3'
 import { z } from 'zod'
 import { handleError } from '../../../../utils'
 
 export default defineEventHandler(async (event) => {
   try {
-    const id = Number(event.context.params!.id) || event.context.params!.id
-
-    const schema = z.object({
-      id: z.number().or(z.string()),
-    })
-
-    schema.parse({ id })
-
     const auth = event.context.auth
 
     if (!auth) {
       throw new Error('unauthorized')
     }
+
+    const schema = z.object({
+      id: z.string().min(1).or(z.number()),
+    })
+
+    // TODO: check in case id is a number
+    const { id } = await getValidatedRouterParams(event, schema.parse)
 
     const refreshTokenEntity = await event.context._authAdapter.refreshToken.findById(id)
 

--- a/src/runtime/server/api/auth/session/revoke/all.delete.ts
+++ b/src/runtime/server/api/auth/session/revoke/all.delete.ts
@@ -1,12 +1,12 @@
 import { defineEventHandler } from 'h3'
-import { handleError } from '../../../../utils'
+import { handleError, createUnauthorizedError } from '../../../../utils'
 
 export default defineEventHandler(async (event) => {
   try {
     const auth = event.context.auth
 
     if (!auth) {
-      throw new Error('unauthorized')
+      throw createUnauthorizedError()
     }
 
     await event.context._authAdapter.refreshToken.deleteManyByUserId(auth.userId, auth.sessionId)

--- a/src/runtime/server/utils/error.ts
+++ b/src/runtime/server/utils/error.ts
@@ -1,4 +1,3 @@
-import { ZodError } from 'zod'
 import { createError, H3Error, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import type { H3Event } from 'h3'
@@ -15,12 +14,7 @@ export async function handleError(
   h3Error.statusCode = 500
 
   if (error) {
-    //
-    if (error instanceof ZodError) {
-      h3Error.message = error.issues[0].path + ' | ' + error.issues[0].message
-      h3Error.statusCode = 400
-    }
-    else if (error.message === 'unauthorized') {
+    if (error.message === 'unauthorized') {
       h3Error.message = 'unauthorized'
       h3Error.statusCode = 401
     }
@@ -33,10 +27,7 @@ export async function handleError(
   }
 
   if (redirect) {
-    await sendRedirect(
-      redirect.event,
-      withQuery(redirect.url, { error: h3Error.message }),
-    )
+    await sendRedirect(redirect.event, withQuery(redirect.url, { error: h3Error.message }))
     return
   }
 

--- a/src/runtime/server/utils/error.ts
+++ b/src/runtime/server/utils/error.ts
@@ -2,6 +2,13 @@ import { createError, H3Error, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import type { H3Event } from 'h3'
 
+export function createUnauthorizedError() {
+  return createError({
+    message: 'unauthorized',
+    statusCode: 401,
+  })
+}
+
 /**
  * Checks error type and set status code accordingly
  */

--- a/src/runtime/server/utils/error.ts
+++ b/src/runtime/server/utils/error.ts
@@ -2,41 +2,25 @@ import { createError, H3Error, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import type { H3Event } from 'h3'
 
-export function createUnauthorizedError() {
-  return createError({
-    message: 'unauthorized',
-    statusCode: 401,
-  })
+export function createCustomError(statusCode: number, message: string) {
+  return createError({ message, statusCode })
 }
 
-/**
- * Checks error type and set status code accordingly
- */
-export async function handleError(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: any,
-  redirect?: { event: H3Event, url: string },
-) {
-  const h3Error = new H3Error('server-error')
-  h3Error.statusCode = 500
+export function createUnauthorizedError() {
+  return createCustomError(401, 'unauthorized')
+}
 
-  if (error) {
-    if (error.message === 'unauthorized') {
-      h3Error.message = 'unauthorized'
-      h3Error.statusCode = 401
+export async function handleError(error: unknown, redirect?: { event: H3Event, url: string }) {
+  if (error instanceof H3Error) {
+    if (redirect) {
+      await sendRedirect(redirect.event, withQuery(redirect.url, { error: error.message }))
+      return
     }
     else {
-      // TODO: only return known messages
-      console.error(error.message)
-      h3Error.message = error.message
-      h3Error.statusCode = 400
+      throw error
     }
   }
 
-  if (redirect) {
-    await sendRedirect(redirect.event, withQuery(redirect.url, { error: h3Error.message }))
-    return
-  }
-
-  throw createError(h3Error)
+  console.error(error)
+  throw createCustomError(500, 'internal-server-error')
 }

--- a/src/runtime/server/utils/error.ts
+++ b/src/runtime/server/utils/error.ts
@@ -1,13 +1,14 @@
 import { createError, H3Error, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import type { H3Event } from 'h3'
+import type { KnownErrors } from '../../types'
 
-export function createCustomError(statusCode: number, message: string) {
+export function createCustomError(statusCode: number, message: KnownErrors) {
   return createError({ message, statusCode })
 }
 
 export function createUnauthorizedError() {
-  return createCustomError(401, 'unauthorized')
+  return createCustomError(401, 'Unauthorized')
 }
 
 export async function handleError(error: unknown, redirect?: { event: H3Event, url: string }) {
@@ -22,5 +23,5 @@ export async function handleError(error: unknown, redirect?: { event: H3Event, u
   }
 
   console.error(error)
-  throw createCustomError(500, 'internal-server-error')
+  throw createCustomError(500, 'Something went wrong')
 }

--- a/src/runtime/server/utils/mail.ts
+++ b/src/runtime/server/utils/mail.ts
@@ -8,8 +8,9 @@ import { useNitroApp } from '#imports'
 export async function sendMail(msg: MailMessage) {
   const config = getConfig()
 
+  // TODO: should not be called in the first place
   if (!config.private.email?.provider) {
-    throw createCustomError(500, 'Please make sure to configure email provider')
+    throw createCustomError(500, 'Something went wrong')
   }
 
   const settings = config.private.email
@@ -22,7 +23,8 @@ export async function sendMail(msg: MailMessage) {
     case 'resend':
       return await withResend(settings.provider.apiKey)
     default:
-      throw createCustomError(500, 'invalid-email-provider')
+      // TODO: should not be called in the first place
+      throw createCustomError(500, 'Something went wrong')
   }
 
   function withSendgrid(apiKey: string) {

--- a/src/runtime/server/utils/mail.ts
+++ b/src/runtime/server/utils/mail.ts
@@ -1,5 +1,6 @@
 import type { MailMessage } from '../../types'
 import { getConfig } from './config'
+import { createCustomError } from './error'
 
 // @ts-expect-error importing an internal module
 import { useNitroApp } from '#imports'
@@ -8,7 +9,7 @@ export async function sendMail(msg: MailMessage) {
   const config = getConfig()
 
   if (!config.private.email?.provider) {
-    throw new Error('Please make sure to configure email provider')
+    throw createCustomError(500, 'Please make sure to configure email provider')
   }
 
   const settings = config.private.email
@@ -21,7 +22,7 @@ export async function sendMail(msg: MailMessage) {
     case 'resend':
       return await withResend(settings.provider.apiKey)
     default:
-      throw new Error('invalid-email-provider')
+      throw createCustomError(500, 'invalid-email-provider')
   }
 
   function withSendgrid(apiKey: string) {

--- a/src/runtime/server/utils/token/fingerprint.ts
+++ b/src/runtime/server/utils/token/fingerprint.ts
@@ -1,5 +1,6 @@
 import { getRequestFingerprint } from 'h3'
 import type { H3Event } from 'h3'
+import { createUnauthorizedError } from '../error'
 
 export async function getFingerprintHash(event: H3Event) {
   const fingerprint = await getRequestFingerprint(event, {
@@ -15,6 +16,6 @@ export async function verifyFingerprint(event: H3Event, hash: string | null) {
   const fingerprintHash = await getFingerprintHash(event)
 
   if (fingerprintHash !== hash) {
-    throw new Error('unauthorized')
+    throw createUnauthorizedError()
   }
 }

--- a/src/runtime/server/utils/token/jwt.ts
+++ b/src/runtime/server/utils/token/jwt.ts
@@ -1,5 +1,6 @@
 import { jwtVerify, SignJWT } from 'jose'
 import type { JWTPayload } from 'jose'
+import { createUnauthorizedError } from '../error'
 
 async function encode(payload: JWTPayload, key: string, maxAge: number) {
   const secret = new TextEncoder().encode(key)
@@ -16,7 +17,7 @@ async function decode<T>(token: string, key: string) {
   const secret = new TextEncoder().encode(key)
 
   const { payload } = await jwtVerify<T>(token, secret).catch(() => {
-    throw new Error('unauthorized')
+    throw createUnauthorizedError()
   })
 
   return payload

--- a/src/runtime/server/utils/token/refreshToken.ts
+++ b/src/runtime/server/utils/token/refreshToken.ts
@@ -3,6 +3,7 @@ import { setCookie, getCookie, deleteCookie, getHeader } from 'h3'
 import type { H3Event } from 'h3'
 import type { RefreshTokenPayload, UserBase, RefreshTokenBase } from '../../../types'
 import { getConfig } from '../config'
+import { createUnauthorizedError } from '../error'
 import { encode, decode } from './jwt'
 
 export async function createRefreshToken(event: H3Event, userId: UserBase['id']) {
@@ -84,14 +85,14 @@ export async function verifyRefreshToken(event: H3Event, refreshToken: string) {
   const refreshTokenEntity = await event.context._authAdapter.refreshToken.findById(payload.id)
 
   if (!refreshTokenEntity) {
-    throw new Error('unauthorized')
+    throw createUnauthorizedError()
   }
 
   const userAgent = getHeader(event, 'user-agent') ?? null
 
   if (refreshTokenEntity.uid !== payload.uid || refreshTokenEntity.userAgent !== userAgent) {
     await event.context._authAdapter.refreshToken.delete(payload.id)
-    throw new Error('unauthorized')
+    throw createUnauthorizedError()
   }
 
   return payload

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -48,6 +48,19 @@ export interface Adapter<Options = unknown> {
   }
 }
 
+export type KnownErrors =
+  'Unauthorized'
+  | 'Account suspended'
+  | 'Account not verified'
+  | 'Wrong credentials'
+  | 'Email already used'
+  | 'Wrong password'
+  | 'Password reset not requested'
+  | 'Oauth name not accessible'
+  | 'Oauth email not accessible'
+  | 'Registration disabled'
+  | 'Something went wrong'
+
 declare module '#app' {
   interface NuxtApp {
     $auth: {

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -149,8 +149,7 @@ export type PrivateConfigWithBackend = {
     maxAge?: number
   }
 
-  oauth?: Partial<
-    Record<
+  oauth?: Record<
       Provider,
       {
         clientId: string
@@ -161,7 +160,6 @@ export type PrivateConfigWithBackend = {
         userUrl: string
       }
     >
-  >
 
   email?: {
     from: string

--- a/tests/register.setup.ts
+++ b/tests/register.setup.ts
@@ -9,5 +9,5 @@ test('should register', async ({ page }) => {
   await page.getByRole('button', { name: 'Register' }).click()
   await page.waitForTimeout(2000)
   const result = await page.getByTestId('registration-result').textContent()
-  expect(result).toMatch(/ok|email-used-with-default/)
+  expect(result).toMatch(/ok|Email already used/)
 })


### PR DESCRIPTION
This PR introduces internal changes in server-side input validation and breaking changes in the returned error messages.

- unauthorized -> Unauthorized
- account-suspended -> Account suspended
- account-not-verified -> Account not verified
- wrong-credentials -> Wrong credentials
- email-used-with-{provider} -> Email already used
- wrong-password -> Wrong password
- reset-not-requested -> Password reset not requested
- name-not-accessible -> Oauth name not accessible
- email-not-accessible -> Oauth email not accessible
- token-not-found -> REMOVED
- Registration disabled -> Added
- Something went wrong -> Added