### PR TITLE
feat: add `provider` to access token payload

### DIFF
--- a/src/runtime/server/api/auth/password/change.put.ts
+++ b/src/runtime/server/api/auth/password/change.put.ts
@@ -6,10 +6,9 @@ export default defineEventHandler(async (event) => {
   const config = getConfig()
 
   try {
-    // TODO: add provider to access token payload
     const auth = event.context.auth
 
-    if (!auth) {
+    if (!auth || auth.provider !== 'default') {
       throw createUnauthorizedError()
     }
 
@@ -24,7 +23,6 @@ export default defineEventHandler(async (event) => {
 
     if (
       !user
-      || user.provider !== 'default'
       || !user.password
       || !compareSync(currentPassword, user.password)
     ) {

--- a/src/runtime/server/utils/token/accessToken.ts
+++ b/src/runtime/server/utils/token/accessToken.ts
@@ -21,9 +21,10 @@ export async function createAccessToken(event: H3Event, user: UserBase, sessionI
   const payload: AccessTokenPayload = {
     ...customClaims,
     sessionId,
+    fingerprint,
     userId: user.id,
     userRole: user.role,
-    fingerprint,
+    provider: user.provider,
   }
 
   const accessToken = await encode(

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -113,6 +113,7 @@ export type AccessTokenPayload = {
   sessionId: RefreshTokenBase['id']
   userRole: string
   fingerprint: string | null
+  provider: string
 }
 
 export type RefreshTokenPayload = {

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -155,8 +155,7 @@ export type PrivateConfigWithBackend = {
   accessToken: {
     jwtSecret: string
     maxAge?: number
-    // TODO: re-check it
-    customClaims?: Record<string, object>
+    customClaims?: Record<string, unknown>
   }
 
   refreshToken: {


### PR DESCRIPTION
This PR adds `provider` to the access token's payload which can used for authorization.