### PR TITLE
refactor: ensure auth refresh flow runs at the end

### DIFF
--- a/playground/plugins/auth.ts
+++ b/playground/plugins/auth.ts
@@ -1,9 +1,9 @@
 import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin({
-  enforce: 'pre',
   hooks: {
-    'auth:loggedIn': () => {
+    'auth:loggedIn': (state) => {
+      console.log('logged in', state)
     },
   },
 })

--- a/src/runtime/plugins/flow.ts
+++ b/src/runtime/plugins/flow.ts
@@ -2,65 +2,72 @@ import { useAuthToken } from '../composables/useAuthToken'
 import type { PublicConfig } from '../types'
 import { defineNuxtPlugin, useAuth, useRouter, useAuthSession } from '#imports'
 
-export default defineNuxtPlugin(async (nuxtApp) => {
-  const publicConfig = nuxtApp.$config.public.auth as PublicConfig
-  const router = useRouter()
-  const token = useAuthToken()
-  const { _loggedInFlag } = useAuthSession()
+export default defineNuxtPlugin({
+  name: 'auth:flow',
+  enforce: 'post',
+  dependsOn: ['auth:provider'],
 
-  nuxtApp.hook('auth:loggedIn', (state) => {
-    _loggedInFlag.value = state
-  })
+  setup: async (nuxtApp) => {
+    const publicConfig = nuxtApp.$config.public.auth as PublicConfig
+    const router = useRouter()
+    const token = useAuthToken()
+    const { _loggedInFlag } = useAuthSession()
 
-  /**
-   * Makes sure to sync login status between tabs
-   */
-  nuxtApp.hook('app:mounted', () => {
-    addEventListener('storage', (event) => {
-      if (event.key === publicConfig.loggedInFlagName) {
-        if (event.oldValue === 'true' && event.newValue === 'false' && token.value) {
-          useAuth()._onLogout()
-        }
-        else if (event.oldValue === 'false' && event.newValue === 'true') {
-          location.reload()
-        }
-      }
+    nuxtApp.hook('auth:loggedIn', (state) => {
+      _loggedInFlag.value = state
     })
-  })
 
-  function isFirstTime() {
-    const isPageFound = router.currentRoute.value?.matched.length > 0
-    const isPrerenderd = typeof nuxtApp.payload.prerenderedAt === 'number'
-    const isServerRendered = nuxtApp.payload.serverRendered
-    const isServerValid = import.meta.server && !isPrerenderd && isPageFound
-    const isClientValid = import.meta.client && (!isServerRendered || isPrerenderd || !isPageFound)
-    return isServerValid || isClientValid
-  }
+    /**
+     * Makes sure to sync login status between tabs
+     */
+    nuxtApp.hook('app:mounted', () => {
+      addEventListener('storage', (event) => {
+        if (event.key === publicConfig.loggedInFlagName) {
+          if (event.oldValue === 'true' && event.newValue === 'false' && token.value) {
+            useAuth()._onLogout()
+          }
+          else if (event.oldValue === 'false' && event.newValue === 'true') {
+            location.reload()
+          }
+        }
+      })
+    })
 
-  function canFetchUser() {
-    const isCallback = router.currentRoute.value?.path === publicConfig.redirect.callback
-    const isCallbackValid = isCallback && !router.currentRoute.value?.query.error
-    const isRefreshTokenExists = !!useAuthSession()._refreshToken.get()
-    return isCallbackValid || _loggedInFlag.value || isRefreshTokenExists
-  }
-
-  /**
-   * Makes sure to refresh access token and set user state if possible (run once)
-   */
-  if (isFirstTime() && canFetchUser()) {
-    await useAuthSession()._refresh()
-    if (token.value) {
-      await useAuth().fetchUser()
+    function isFirstTime() {
+      const isPageFound = router.currentRoute.value?.matched.length > 0
+      const isPrerenderd = typeof nuxtApp.payload.prerenderedAt === 'number'
+      const isServerRendered = nuxtApp.payload.serverRendered
+      const isServerValid = import.meta.server && !isPrerenderd && isPageFound
+      const isClientValid = import.meta.client && (!isServerRendered || isPrerenderd || !isPageFound)
+      return isServerValid || isClientValid
     }
-  }
 
-  /**
-   * Calls loggedIn hook and sets the loggedIn flag in localStorage
-   */
-  if (token.value) {
-    await nuxtApp.callHook('auth:loggedIn', true)
-  }
-  else {
-    _loggedInFlag.value = false
-  }
+    function canFetchUser() {
+      const isCallback = router.currentRoute.value?.path === publicConfig.redirect.callback
+      const isCallbackValid = isCallback && !router.currentRoute.value?.query.error
+      const isRefreshTokenExists = !!useAuthSession()._refreshToken.get()
+      return isCallbackValid || _loggedInFlag.value || isRefreshTokenExists
+    }
+
+    /**
+     * Makes sure to refresh access token and set user state if possible (run once)
+     */
+    if (isFirstTime() && canFetchUser()) {
+      await useAuthSession()._refresh()
+      if (token.value) {
+        await useAuth().fetchUser()
+      }
+    }
+
+    /**
+     * Calls loggedIn hook and sets the loggedIn flag in localStorage
+     */
+    if (token.value) {
+      console.log('logged in from flow plugin')
+      await nuxtApp.callHook('auth:loggedIn', true)
+    }
+    else {
+      _loggedInFlag.value = false
+    }
+  },
 })

--- a/src/runtime/plugins/provider.ts
+++ b/src/runtime/plugins/provider.ts
@@ -2,35 +2,39 @@ import { defu } from 'defu'
 import type { PublicConfig } from '../types'
 import { defineNuxtPlugin, useAuthSession, useRequestHeaders } from '#imports'
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const publicConfig = nuxtApp.$config.public.auth as PublicConfig
-  const reqHeaders = useRequestHeaders(['user-agent'])
+export default defineNuxtPlugin({
+  name: 'auth:provider',
 
-  /**
-   * A $fetch instance with auto authorization handler
-   */
-  const fetch = $fetch.create({
-    baseURL: publicConfig.backendBaseUrl,
+  setup: (nuxtApp) => {
+    const publicConfig = nuxtApp.$config.public.auth as PublicConfig
+    const reqHeaders = useRequestHeaders(['user-agent'])
 
-    async onRequest({ options }) {
-      const accessToken = await useAuthSession().getAccessToken()
+    /**
+     * A $fetch instance with auto authorization handler
+     */
+    const fetch = $fetch.create({
+      baseURL: publicConfig.backendBaseUrl,
 
-      if (accessToken) {
-        options.headers = defu(options.headers, reqHeaders, {
-          authorization: 'Bearer ' + accessToken,
-        })
-      }
+      async onRequest({ options }) {
+        const accessToken = await useAuthSession().getAccessToken()
 
-      options.credentials ||= 'omit'
-    },
-  })
+        if (accessToken) {
+          options.headers = defu(options.headers, reqHeaders, {
+            authorization: 'Bearer ' + accessToken,
+          })
+        }
 
-  return {
-    provide: {
-      auth: {
-        fetch,
-        _refreshPromise: null,
+        options.credentials ||= 'omit'
       },
-    },
-  }
+    })
+
+    return {
+      provide: {
+        auth: {
+          fetch,
+          _refreshPromise: null,
+        },
+      },
+    }
+  },
 })

--- a/src/setup/frontend.ts
+++ b/src/setup/frontend.ts
@@ -45,8 +45,8 @@ export function setupFrontend(options: ModuleOptions, nuxt: Nuxt) {
   const { resolve } = createResolver(import.meta.url)
 
   // Add nuxt plugins
-  addPlugin(resolve('../runtime/plugins/provider'), { append: true })
-  addPlugin(resolve('../runtime/plugins/flow'), { append: true })
+  addPlugin(resolve('../runtime/plugins/provider'))
+  addPlugin(resolve('../runtime/plugins/flow'))
 
   // Add composables
   addImports([


### PR DESCRIPTION
The module has a plugin named 'flow' that is responsible for refreshing active session and calling `auth:loggedIn` hook. Listeners to this hook should be registered before running the plugin. Previously the user should ensure that, now the module does.

```ts
export default defineNuxtPlugin({
 enforce: 'pre', //<-- No longer needed
  hooks: {
    'auth:loggedIn': (state) => { },
  },
})

```