### PR TITLE
feat: allow augmenting adapter types

### DIFF
--- a/playground/index.d.ts
+++ b/playground/index.d.ts
@@ -1,0 +1,6 @@
+declare module '#build/types/auth_adapter' {
+  interface User {
+  }
+}
+
+export {}

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,10 +3,6 @@ import { defineNuxtConfig } from 'nuxt/config'
 export default defineNuxtConfig({
   modules: ['../src/module'],
 
-  runtimeConfig: {
-    adapter: 'unstorage',
-  },
-
   ssr: process.env.NUXT_SSR !== 'false',
 
   app: {

--- a/playground/server/plugins/prisma.ts
+++ b/playground/server/plugins/prisma.ts
@@ -4,12 +4,10 @@ import consola from 'consola'
 import { definePrismaAdapter } from '#auth'
 
 // @ts-expect-error importing an internal module
-import { defineNitroPlugin, useRuntimeConfig } from '#imports'
+import { defineNitroPlugin } from '#imports'
 
 export default defineNitroPlugin((nitroApp: NitroApp) => {
-  const config = useRuntimeConfig()
-
-  if (config.adapter === 'prisma') {
+  if (process.env.NUXT_ADAPTER === 'prisma') {
     consola.success('Running with Prisma adapter')
 
     const prisma = new PrismaClient()

--- a/playground/server/plugins/unstorage.ts
+++ b/playground/server/plugins/unstorage.ts
@@ -5,12 +5,10 @@ import consola from 'consola'
 import { defineUnstorageAdapter } from '#auth'
 
 // @ts-expect-error importing an internal module
-import { defineNitroPlugin, useRuntimeConfig } from '#imports'
+import { defineNitroPlugin } from '#imports'
 
 export default defineNitroPlugin((nitroApp: NitroApp) => {
-  const config = useRuntimeConfig()
-
-  if (config.adapter === 'unstorage') {
+  if (process.env.NUXT_ADAPTER === 'unstorage') {
     consola.success('Running with Unstorage adapter')
 
     const storage = createStorage({

--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -54,7 +54,7 @@ export function useAuth() {
   /**
    * Login via oauth provider
    */
-  async function loginWithProvider(provider: string) {
+  async function loginWithProvider(provider: User['provider']) {
     // The protected page the user has visited before redirect to login page
     const returnToPath = useRoute().query.redirect?.toString()
 

--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -1,7 +1,8 @@
 import { joinURL } from 'ufo'
-import type { Response, UserBase, PublicConfig, AuthenticationData } from '../types'
+import type { Response, PublicConfig, AuthenticationData } from '../types'
 import { useAuthToken } from './useAuthToken'
 import { useRuntimeConfig, useRoute, useAuthSession, navigateTo, useNuxtApp } from '#imports'
+import type { User } from '#build/types/auth_adapter'
 
 interface LoginInput {
   email: string
@@ -74,7 +75,7 @@ export function useAuth() {
   async function fetchUser() {
     const { user } = useAuthSession()
     try {
-      user.value = await useNuxtApp().$auth.fetch<UserBase>('/api/auth/me')
+      user.value = await useNuxtApp().$auth.fetch<User>('/api/auth/me')
     }
     catch (err) {
       user.value = null

--- a/src/runtime/composables/useAuthSession.ts
+++ b/src/runtime/composables/useAuthSession.ts
@@ -1,8 +1,9 @@
 import { deleteCookie, getCookie, splitCookiesString, appendResponseHeader } from 'h3'
 import type { Ref } from 'vue'
-import type { UserBase, Session, Response, PublicConfig, PrivateConfig, AuthenticationData } from '../types'
+import type { Response, PublicConfig, PrivateConfig, AuthenticationData } from '../types'
 import { useAuthToken } from './useAuthToken'
 import { useRequestEvent, useRuntimeConfig, useState, useRequestHeaders, useNuxtApp, useAuth } from '#imports'
+import type { User, Session } from '#build/types/auth_adapter'
 
 export function useAuthSession() {
   const event = useRequestEvent()
@@ -26,7 +27,7 @@ export function useAuthSession() {
     },
   }
 
-  const user: Ref<UserBase | null | undefined> = useState<UserBase | null | undefined>('auth-user', () => null)
+  const user: Ref<User | null | undefined> = useState<User | null | undefined>('auth-user', () => null)
 
   async function _refresh() {
     async function handler() {

--- a/src/runtime/server/api/auth/session/index.get.ts
+++ b/src/runtime/server/api/auth/session/index.get.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler } from 'h3'
 import { handleError, createUnauthorizedError } from '../../../utils'
-import type { Session } from '../../../../types'
+import type { Session } from '#build/types/auth_adapter'
 
 export default defineEventHandler(async (event) => {
   try {

--- a/src/runtime/server/utils/adapter/unstorage.ts
+++ b/src/runtime/server/utils/adapter/unstorage.ts
@@ -1,7 +1,7 @@
 import type { Storage } from 'unstorage'
 import { randomUUID } from 'uncrypto'
-import type { UserBase, RefreshTokenBase } from '../../../types'
 import { defineAdapter } from './utils'
+import type { User, RefreshToken } from '#build/types/auth_adapter'
 
 export const defineUnstorageAdapter = defineAdapter<Storage>((client) => {
   if (!client) {
@@ -13,11 +13,11 @@ export const defineUnstorageAdapter = defineAdapter<Storage>((client) => {
 
     user: {
       async findById(id) {
-        return client.getItem<UserBase>(`users:${id}`)
+        return client.getItem<User>(`users:${id}`)
       },
 
       async findByEmail(email) {
-        const itemsAll = await client.getKeys('users').then(keys => client.getItems<UserBase>(keys))
+        const itemsAll = await client.getKeys('users').then(keys => client.getItems<User>(keys))
         const itemsFiltered = itemsAll.find(item => item.value.email === email)
         return itemsFiltered?.value ?? null
       },
@@ -45,12 +45,12 @@ export const defineUnstorageAdapter = defineAdapter<Storage>((client) => {
 
     refreshToken: {
       async findById(id) {
-        return client.getItem<RefreshTokenBase>(`refresh_tokens:${id}`)
+        return client.getItem<RefreshToken>(`refresh_tokens:${id}`)
       },
 
       async findManyByUserId(id) {
         const items = await client.getKeys('refresh_tokens').then((keys) => {
-          return client.getItems<RefreshTokenBase>(keys)
+          return client.getItems<RefreshToken>(keys)
         })
         const itemsFiltered = items.filter(item => item.value.userId === id)
         return itemsFiltered.map(item => item.value)

--- a/src/runtime/server/utils/adapter/utils.ts
+++ b/src/runtime/server/utils/adapter/utils.ts
@@ -1,4 +1,4 @@
-import type { Adapter } from '../../../types'
+import type { Adapter } from '#build/types/auth_adapter'
 
 type AdapterFactory<Options> = (opts?: Options) => Adapter<Options>
 

--- a/src/runtime/server/utils/token/accessToken.ts
+++ b/src/runtime/server/utils/token/accessToken.ts
@@ -1,12 +1,12 @@
 import { getRequestHeader } from 'h3'
 import type { H3Event } from 'h3'
-import type { AccessTokenPayload, UserBase, Session } from '../../../types'
 import { getConfig } from '../config'
 import { mustache } from '../mustache'
 import { encode, decode } from './jwt'
 import { getFingerprintHash, verifyFingerprint } from './fingerprint'
+import type { User, Session, AccessTokenPayload } from '#build/types/auth_adapter'
 
-export async function createAccessToken(event: H3Event, user: UserBase, sessionId: Session['id']) {
+export async function createAccessToken(event: H3Event, user: User, sessionId: Session['id']) {
   const config = getConfig()
 
   let customClaims = config.private.accessToken.customClaims || {}

--- a/src/runtime/server/utils/token/emailVerify.ts
+++ b/src/runtime/server/utils/token/emailVerify.ts
@@ -1,6 +1,10 @@
-import type { EmailVerifyPayload } from '../../../types'
 import { getConfig } from '../config'
 import { decode, encode } from './jwt'
+import type { User } from '#build/types/auth_adapter'
+
+type EmailVerifyPayload = {
+  userId: User['id']
+}
 
 export async function createEmailVerifyToken(payload: EmailVerifyPayload) {
   const config = getConfig()

--- a/src/runtime/server/utils/token/passwordReset.ts
+++ b/src/runtime/server/utils/token/passwordReset.ts
@@ -1,6 +1,10 @@
-import type { ResetPasswordPayload } from '../../../types'
 import { getConfig } from '../config'
 import { encode, decode } from './jwt'
+import type { User } from '#build/types/auth_adapter'
+
+type ResetPasswordPayload = {
+  userId: User['id']
+}
 
 export async function createResetPasswordToken(payload: ResetPasswordPayload) {
   const config = getConfig()

--- a/src/runtime/server/utils/token/refreshToken.ts
+++ b/src/runtime/server/utils/token/refreshToken.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from 'uncrypto'
 import { setCookie, getCookie, deleteCookie, getHeader } from 'h3'
 import type { H3Event } from 'h3'
-import type { RefreshTokenPayload, UserBase, RefreshTokenBase } from '../../../types'
 import { getConfig } from '../config'
 import { createUnauthorizedError } from '../error'
 import { encode, decode } from './jwt'
+import type { User, RefreshToken, RefreshTokenPayload } from '#build/types/auth_adapter'
 
-export async function createRefreshToken(event: H3Event, userId: UserBase['id']) {
+export async function createRefreshToken(event: H3Event, userId: User['id']) {
   const userAgent = getHeader(event, 'user-agent')
 
   const uid = randomUUID()
@@ -47,7 +47,7 @@ export async function decodeRefreshToken(refreshToken: string) {
   return payload
 }
 
-export async function updateRefreshToken(event: H3Event, id: RefreshTokenBase['id'], userId: UserBase['id']) {
+export async function updateRefreshToken(event: H3Event, id: RefreshToken['id'], userId: User['id']) {
   const uid = randomUUID()
 
   await event.context._authAdapter.refreshToken.update(id, {

--- a/src/runtime/server/utils/user.ts
+++ b/src/runtime/server/utils/user.ts
@@ -2,13 +2,14 @@ import type { H3Event } from 'h3'
 import { getConfig } from './config'
 import { generateAvatar } from './avatar'
 import { createCustomError } from './error'
+import type { User } from '#build/types/auth_adapter'
 
 interface CreateAccountInput {
   name: string
   email: string
   password?: string
   verified?: boolean
-  provider?: string
+  provider?: User['provider']
   picture?: string
 }
 

--- a/src/runtime/types/adapter.d.ts
+++ b/src/runtime/types/adapter.d.ts
@@ -1,4 +1,4 @@
-export interface UserBase {
+export interface User {
   id: number | string
   name: string
   email: string
@@ -13,37 +13,66 @@ export interface UserBase {
   updatedAt: Date
 }
 
-export interface RefreshTokenBase {
+export interface RefreshToken {
   id: number | string
   uid: string
-  userId: number | string
+  userId: User['id']
   userAgent: string | null
   createdAt: Date
   updatedAt: Date
 }
 
-type UserCreateInput = Pick<UserBase, 'name' | 'email' | 'password' | 'picture' | 'provider' | 'role' | 'verified'>
-type UserCreateOutput = Pick<UserBase, 'id'>
-type UserUpdateInput = Omit<Partial<UserBase>, 'id'>
-type RefreshTokenCreateInput = Pick<RefreshTokenBase, 'uid' | 'userAgent' | 'userId'>
-type RefreshTokenCreateOutput = Pick<RefreshTokenBase, 'id'>
-type RefreshTokenUpdateInput = Pick<RefreshTokenBase, 'uid'>
+export interface Session {
+  id: RefreshToken['id']
+  current: boolean
+  ua: string | null
+  updatedAt: Date
+  createdAt: Date
+}
+
+export type AccessTokenPayload = {
+  userId: User['id']
+  sessionId: RefreshToken['id']
+  userRole: User['role']
+  fingerprint: string | null
+  provider: User['provider']
+}
+
+export type RefreshTokenPayload = {
+  id: RefreshToken['id']
+  uid: string
+  userId: User['id']
+}
+
+declare module 'h3' {
+  interface H3EventContext {
+    _authAdapter: Adapter
+    auth?: AccessTokenPayload
+  }
+}
+
+type UserCreateInput = Pick<User, 'name' | 'email' | 'password' | 'picture' | 'provider' | 'role' | 'verified'>
+type UserCreateOutput = Pick<User, 'id'>
+type UserUpdateInput = Omit<Partial<User>, 'id'>
+type RefreshTokenCreateInput = Pick<RefreshToken, 'uid' | 'userAgent' | 'userId'>
+type RefreshTokenCreateOutput = Pick<RefreshToken, 'id'>
+type RefreshTokenUpdateInput = Pick<RefreshToken, 'uid'>
 
 export interface Adapter<Options = unknown> {
   name: string
   options?: Options
   user: {
-    findById: (id: UserBase['id']) => Promise<UserBase | null>
-    findByEmail: (email: UserBase['email']) => Promise<UserBase | null>
+    findById: (id: User['id']) => Promise<User | null>
+    findByEmail: (email: User['email']) => Promise<User | null>
     create: (input: UserCreateInput) => Promise<UserCreateOutput>
-    update: (id: UserBase['id'], input: UserUpdateInput) => Promise<void>
+    update: (id: User['id'], input: UserUpdateInput) => Promise<void>
   }
   refreshToken: {
-    findById: (id: RefreshTokenBase['id']) => Promise<RefreshTokenBase | null>
-    findManyByUserId: (id: UserBase['id']) => Promise<RefreshTokenBase[]>
+    findById: (id: RefreshToken['id']) => Promise<RefreshToken | null>
+    findManyByUserId: (id: User['id']) => Promise<RefreshToken[]>
     create: (input: RefreshTokenCreateInput) => Promise<RefreshTokenCreateOutput>
-    update: (id: RefreshTokenBase['id'], input: RefreshTokenUpdateInput) => Promise<void>
-    delete: (id: RefreshTokenBase['id']) => Promise<void>
-    deleteManyByUserId: (id: UserBase['id'], excludeId?: RefreshTokenBase['id']) => Promise<void>
+    update: (id: RefreshToken['id'], input: RefreshTokenUpdateInput) => Promise<void>
+    delete: (id: RefreshToken['id']) => Promise<void>
+    deleteManyByUserId: (id: User['id'], excludeId?: RefreshToken['id']) => Promise<void>
   }
 }

--- a/src/runtime/types/augment.d.ts
+++ b/src/runtime/types/augment.d.ts
@@ -1,7 +1,6 @@
 import type { FetchError } from 'ofetch'
 import type { H3Error } from 'h3'
-import type { AccessTokenPayload, MailMessage } from './common'
-import type { Adapter } from './adapter'
+import type { MailMessage } from './common'
 
 declare module '#app' {
   interface NuxtApp {
@@ -28,13 +27,6 @@ declare module 'vue' {
       fetch: typeof $fetch
       _refreshPromise: Promise<void> | null
     }
-  }
-}
-
-declare module 'h3' {
-  interface H3EventContext {
-    _authAdapter: Adapter
-    auth?: AccessTokenPayload
   }
 }
 

--- a/src/runtime/types/common.d.ts
+++ b/src/runtime/types/common.d.ts
@@ -1,5 +1,3 @@
-import type { RefreshTokenBase, UserBase } from './adapter'
-
 export type KnownErrors =
   'Unauthorized'
   | 'Account suspended'
@@ -14,40 +12,10 @@ export type KnownErrors =
   | 'Registration disabled'
   | 'Something went wrong'
 
-export interface Session {
-  id: RefreshTokenBase['id']
-  current: boolean
-  ua: string | null
-  updatedAt: Date
-  createdAt: Date
-}
-
 export type MailMessage = {
   to: string
   subject: string
   html: string
-}
-
-export type ResetPasswordPayload = {
-  userId: UserBase['id']
-}
-
-export type EmailVerifyPayload = {
-  userId: UserBase['id']
-}
-
-export type AccessTokenPayload = {
-  userId: UserBase['id']
-  sessionId: RefreshTokenBase['id']
-  userRole: string
-  fingerprint: string | null
-  provider: string
-}
-
-export type RefreshTokenPayload = {
-  id: RefreshTokenBase['id']
-  uid: string
-  userId: UserBase['id']
 }
 
 export interface AuthenticationData {

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -1,4 +1,3 @@
-export * from './adapter'
 export * from './augment'
 export * from './config'
 export * from './common'

--- a/src/setup/frontend.ts
+++ b/src/setup/frontend.ts
@@ -1,4 +1,4 @@
-import { addPlugin, createResolver, addImports, addRouteMiddleware } from '@nuxt/kit'
+import { addPlugin, createResolver, addImports, addRouteMiddleware, addTypeTemplate } from '@nuxt/kit'
 import { defu } from 'defu'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleOptions } from '../runtime/types'
@@ -75,5 +75,10 @@ export function setupFrontend(options: ModuleOptions, nuxt: Nuxt) {
     name: '_auth-common',
     path: resolve('../runtime/middleware/common'),
     global: true,
+  })
+
+  addTypeTemplate({
+    filename: 'types/auth_adapter.d.ts',
+    src: resolve('../runtime/types/adapter.d.ts'),
   })
 }


### PR DESCRIPTION
This PR permits augmenting the `User` and `RefreshToken` interfaces according to your data definition.

```ts
declare module '#build/types/auth_adapter' {
  interface User { }
  interface RefreshToken { }
}

export {}

```