### PR TITLE
feat: add Email action timeout

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -51,9 +51,6 @@ export default defineNuxtConfig({
 
     email: {
       from: process.env.AUTH_EMAIL_FROM!,
-      provider: {
-        name: 'hook',
-      },
     },
 
     registration: {

--- a/playground/server/plugins/email.ts
+++ b/playground/server/plugins/email.ts
@@ -1,0 +1,11 @@
+import type { NitroApp } from 'nitropack'
+import consola from 'consola'
+
+// @ts-expect-error importing an internal module
+import { defineNitroPlugin } from '#imports'
+
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  nitroApp.hooks.hook('auth:email', (from, message) => {
+    consola.info('Email', from, message)
+  })
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -46,6 +46,9 @@ export default defineNuxtModule<ModuleOptions>({
       passwordValidationRegex: '^.+$',
       emailValidationRegex: '^.+$',
     },
+    email: {
+      actionTimeout: 15 * 60,
+    },
   },
 
   setup(options, nuxt) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,7 +47,11 @@ export default defineNuxtModule<ModuleOptions>({
       emailValidationRegex: '^.+$',
     },
     email: {
-      actionTimeout: 15 * 60,
+      actionTimeout: 30 * 60,
+      from: '',
+      provider: {
+        name: 'hook',
+      },
     },
   },
 

--- a/src/runtime/server/api/auth/email/request.post.ts
+++ b/src/runtime/server/api/auth/email/request.post.ts
@@ -33,7 +33,7 @@ export default defineEventHandler(async (event) => {
             ...user,
             link,
             validityInMinutes: Math.round(
-              config.private.accessToken.maxAge! / 60,
+              config.private.email!.actionTimeout! / 60,
             ),
           },
         ),

--- a/src/runtime/server/api/auth/password/request.post.ts
+++ b/src/runtime/server/api/auth/password/request.post.ts
@@ -32,7 +32,7 @@ export default defineEventHandler(async (event) => {
             ...user,
             link,
             validityInMinutes: Math.round(
-              config.private.accessToken.maxAge! / 60,
+              config.private.email!.actionTimeout! / 60,
             ),
           },
         ),

--- a/src/runtime/server/utils/mail.ts
+++ b/src/runtime/server/utils/mail.ts
@@ -1,6 +1,5 @@
 import type { MailMessage } from '../../types'
 import { getConfig } from './config'
-import { createCustomError } from './error'
 
 // @ts-expect-error importing an internal module
 import { useNitroApp } from '#imports'
@@ -8,8 +7,8 @@ import { useNitroApp } from '#imports'
 export async function sendMail(msg: MailMessage) {
   const config = getConfig()
 
-  if (!config.private.email?.provider) {
-    throw createCustomError(500, 'Something went wrong')
+  if (!config.private.email?.from) {
+    throw new Error('[nuxt-auth] Email `from` address is not set')
   }
 
   const settings = config.private.email
@@ -22,7 +21,7 @@ export async function sendMail(msg: MailMessage) {
     case 'resend':
       return await withResend(settings.provider.apiKey)
     default:
-      throw createCustomError(500, 'Something went wrong')
+      throw new Error('[nuxt-auth] invalid email `provider`')
   }
 
   function withSendgrid(apiKey: string) {

--- a/src/runtime/server/utils/token/emailVerify.ts
+++ b/src/runtime/server/utils/token/emailVerify.ts
@@ -12,7 +12,7 @@ export async function createEmailVerifyToken(payload: EmailVerifyPayload) {
   const emailVerifyToken = await encode(
     payload,
     config.private.accessToken.jwtSecret + 'e',
-    config.private.accessToken.maxAge!,
+    config.private.email!.actionTimeout!,
   )
 
   return emailVerifyToken

--- a/src/runtime/server/utils/token/passwordReset.ts
+++ b/src/runtime/server/utils/token/passwordReset.ts
@@ -11,7 +11,7 @@ export async function createResetPasswordToken(payload: ResetPasswordPayload) {
   const resetPasswordToken = await encode(
     payload,
     config.private.accessToken.jwtSecret + 'p',
-    config.private.accessToken.maxAge!,
+    config.private.email!.actionTimeout!,
   )
 
   return resetPasswordToken

--- a/src/runtime/types/config.d.ts
+++ b/src/runtime/types/config.d.ts
@@ -70,7 +70,7 @@ export type PrivateConfigWithBackend = {
   email?: {
     from: string
     actionTimeout?: number
-    provider: MailSendgridProvider | MailResendProvider | MailHookProvider
+    provider?: MailSendgridProvider | MailResendProvider | MailHookProvider
     templates?: {
       passwordReset?: string
       emailVerify?: string

--- a/src/runtime/types/config.d.ts
+++ b/src/runtime/types/config.d.ts
@@ -69,6 +69,7 @@ export type PrivateConfigWithBackend = {
 
   email?: {
     from: string
+    actionTimeout?: number
     provider: MailSendgridProvider | MailResendProvider | MailHookProvider
     templates?: {
       passwordReset?: string

--- a/src/setup/backend.ts
+++ b/src/setup/backend.ts
@@ -124,6 +124,10 @@ export function setupBackend(options: ModuleOptions, nuxt: Nuxt) {
     handler: resolve('../runtime/server/api/auth/avatar.get'),
   })
 
+  if (!options.registration.enabled) {
+    info('Registration is disabled')
+  }
+
   if (options.oauth && Object.keys(options.oauth).length) {
     if (options.redirect.callback) {
       addServerHandler({
@@ -140,16 +144,11 @@ export function setupBackend(options: ModuleOptions, nuxt: Nuxt) {
       warnRequiredOption('redirect.callback')
     }
   }
-
-  if (!options.registration.enabled) {
-    info('Registration is disabled')
+  else {
+    info('Oauth login is disabled')
   }
 
-  if (!options.email?.provider) {
-    info('No email provider is set')
-  }
-
-  if (options.email?.provider) {
+  if (options.email?.from) {
     if (options.redirect.passwordReset) {
       addServerHandler({
         route: '/api/auth/password/request',
@@ -199,5 +198,8 @@ export function setupBackend(options: ModuleOptions, nuxt: Nuxt) {
       const passwordResetPath = resolve('../runtime/templates/password_reset.html')
       options.email.templates.passwordReset = readFileSync(passwordResetPath, 'utf-8')
     }
+  }
+  else {
+    info('Email verification and password reset are disabled')
   }
 }


### PR DESCRIPTION
This PR adds `email.actionTimeout` to set action (email verification, password reset) validity in seconds instead of defaulting to the access token max-age. 

It also sets `hook` as the default email provider.