### PR TITLE
fix: allow overwriting ID type

### DIFF
--- a/playground/index.d.ts
+++ b/playground/index.d.ts
@@ -1,6 +1,6 @@
 declare module '#build/types/auth_adapter' {
-  interface User {
-  }
+  type UserId = number
+  type RefreshTokenId = number
 }
 
 export {}

--- a/playground/index.d.ts
+++ b/playground/index.d.ts
@@ -1,6 +1,4 @@
 declare module '#build/types/auth_adapter' {
-  type UserId = number
-  type RefreshTokenId = number
 }
 
 export {}

--- a/playground/prisma/schema.prisma
+++ b/playground/prisma/schema.prisma
@@ -11,7 +11,7 @@ datasource db {
 }
 
 model User {
-  id                     Int            @id @default(autoincrement())
+  id                     String         @id @default(cuid())
   name                   String
   email                  String         @unique
   picture                String
@@ -27,9 +27,9 @@ model User {
 }
 
 model RefreshToken {
-  id        Int      @id @default(autoincrement())
+  id        String   @id @default(cuid())
   uid       String
-  userId    Int
+  userId    String
   user      User     @relation(fields: [userId], references: [id])
   userAgent String?
   createdAt DateTime @default(now())

--- a/src/runtime/server/api/auth/session/revoke/[id].delete.ts
+++ b/src/runtime/server/api/auth/session/revoke/[id].delete.ts
@@ -11,11 +11,12 @@ export default defineEventHandler(async (event) => {
     }
 
     const schema = z.object({
-      id: z.string().min(1).or(z.number()),
+      id: z.string().min(1),
     })
 
     const params = await getValidatedRouterParams(event, schema.parse)
 
+    // @ts-expect-error id can either be string or number
     params.id = Number.isNaN(Number(params.id)) ? params.id : Number(params.id)
 
     const refreshTokenEntity = await event.context._authAdapter.refreshToken.findById(params.id, auth.userId)

--- a/src/runtime/types/adapter.d.ts
+++ b/src/runtime/types/adapter.d.ts
@@ -1,5 +1,10 @@
+/**
+ * Resolves to 'string' if T is 'any' (unresolved) and 'number' if T is a number
+ */
+type NumberOrString<T> = (T extends string ? string : number) extends number ? number : string
+
 export interface User {
-  id: number | string
+  id: NumberOrString<UserId>
   name: string
   email: string
   picture: string
@@ -14,7 +19,7 @@ export interface User {
 }
 
 export interface RefreshToken {
-  id: number | string
+  id: NumberOrString<RefreshTokenId>
   uid: string
   userId: User['id']
   userAgent: string | null


### PR DESCRIPTION
By default the ids of tables are strings. When using numbers this PR allows changing types.

```ts
declare module '#build/types/auth_adapter' {
 type UserId = number
 type RefreshTokenId = number
}
```