### PR TITLE
feat: add `auth:registration` and `auth:error` hooks

### DIFF
--- a/playground/server/plugins/hooks.ts
+++ b/playground/server/plugins/hooks.ts
@@ -8,4 +8,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
   nitroApp.hooks.hook('auth:email', (from, message) => {
     consola.info('Email', from, message)
   })
+
+  nitroApp.hooks.hook('auth:registration', (user) => {
+    consola.info('Registration', user)
+  })
+
+  nitroApp.hooks.hook('auth:error', consola.error)
 })

--- a/src/runtime/server/utils/adapter/prisma.ts
+++ b/src/runtime/server/utils/adapter/prisma.ts
@@ -28,9 +28,6 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       async create(data) {
         return prisma.user.create({
           data,
-          select: {
-            id: true,
-          },
         })
       },
 

--- a/src/runtime/server/utils/adapter/unstorage.ts
+++ b/src/runtime/server/utils/adapter/unstorage.ts
@@ -23,15 +23,15 @@ export const defineUnstorageAdapter = defineAdapter<Storage>((storage) => {
       },
 
       async create(data) {
-        const id = randomUUID()
-        await storage.setItem(`users:id:${id}:data`, {
+        const user: User = {
           ...data,
-          id,
+          id: randomUUID(),
           createdAt: new Date(),
           updatedAt: new Date(),
-        })
-        await storage.setItem(`users:email:${data.email}`, id)
-        return { id }
+        }
+        await storage.setItem(`users:id:${user.id}:data`, user)
+        await storage.setItem(`users:email:${data.email}`, user.id)
+        return user
       },
 
       async update(id, data) {

--- a/src/runtime/server/utils/error.ts
+++ b/src/runtime/server/utils/error.ts
@@ -1,7 +1,11 @@
 import { createError, H3Error, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import type { H3Event } from 'h3'
+import type { NitroApp } from 'nitropack'
 import type { KnownErrors } from '../../types/common'
+
+// @ts-expect-error importing an internal module
+import { useNitroApp } from '#imports'
 
 export function createCustomError(statusCode: number, message: KnownErrors) {
   return createError({ message, statusCode })
@@ -22,6 +26,8 @@ export async function handleError(error: unknown, redirect?: { event: H3Event, u
     }
   }
 
-  console.error(error)
+  const nitroApp = useNitroApp() as NitroApp
+  await nitroApp.hooks.callHook('auth:error', error)
+
   throw createCustomError(500, 'Something went wrong')
 }

--- a/src/runtime/server/utils/mail.ts
+++ b/src/runtime/server/utils/mail.ts
@@ -1,4 +1,5 @@
 import { $fetch } from 'ofetch'
+import type { NitroApp } from 'nitropack'
 import type { MailMessage } from '../../types/common'
 import { getConfig } from './config'
 
@@ -62,7 +63,7 @@ export async function sendMail(msg: MailMessage) {
   }
 
   function withHook() {
-    const nitroApp = useNitroApp()
+    const nitroApp = useNitroApp() as NitroApp
     return nitroApp.hooks.callHook('auth:email', settings.from, msg)
   }
 }

--- a/src/runtime/types/adapter.d.ts
+++ b/src/runtime/types/adapter.d.ts
@@ -28,7 +28,7 @@ export interface RefreshToken {
 }
 
 type UserCreateInput = Pick<User, 'name' | 'email' | 'password' | 'picture' | 'provider' | 'role' | 'verified'>
-type UserCreateOutput = Pick<User, 'id'>
+type UserCreateOutput = User
 type UserUpdateInput = Omit<Partial<User>, 'id'>
 type RefreshTokenCreateInput = Pick<RefreshToken, 'uid' | 'userAgent' | 'userId'>
 type RefreshTokenCreateOutput = Pick<RefreshToken, 'id'>

--- a/src/runtime/types/common.d.ts
+++ b/src/runtime/types/common.d.ts
@@ -31,6 +31,7 @@ declare module 'nitropack' {
   interface NitroRuntimeHooks {
     'auth:email': (from: string, msg: MailMessage) => Promise<void> | void
     'auth:registration': (user: User) => Promise<void> | void
+    'auth:error': (error: unknown) => Promise<void> | void
   }
 }
 

--- a/src/runtime/types/common.d.ts
+++ b/src/runtime/types/common.d.ts
@@ -30,6 +30,7 @@ declare module 'h3' {
 declare module 'nitropack' {
   interface NitroRuntimeHooks {
     'auth:email': (from: string, msg: MailMessage) => Promise<void> | void
+    'auth:registration': (user: User) => Promise<void> | void
   }
 }
 


### PR DESCRIPTION
```ts
  interface NitroRuntimeHooks {
    'auth:registration': (user: User) => Promise<void> | void
    'auth:error': (error: unknown) => Promise<void> | void
  }
```

`auth:registration` hook allows performing custom logic after user registration.
`auth:error` hook allows handling **server** errors thrown by the module.