### PR TITLE
refactor!: rename the data model `RefreshToken` to `Session`

### DIFF
--- a/playground/prisma/schema.prisma
+++ b/playground/prisma/schema.prisma
@@ -11,22 +11,22 @@ datasource db {
 }
 
 model User {
-  id                     String         @id @default(cuid())
+  id                     String    @id @default(cuid())
   name                   String
-  email                  String         @unique
+  email                  String    @unique
   picture                String
   role                   String
   provider               String
   password               String?
   verified               Boolean
   suspended              Boolean?
-  refreshTokens          RefreshToken[]
+  sessions               Session[]
   requestedPasswordReset Boolean?
-  createdAt              DateTime       @default(now())
-  updatedAt              DateTime       @updatedAt
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
 }
 
-model RefreshToken {
+model Session {
   id        String   @id @default(cuid())
   uid       String
   userId    String

--- a/src/runtime/composables/useAuthSession.ts
+++ b/src/runtime/composables/useAuthSession.ts
@@ -1,6 +1,6 @@
 import { deleteCookie, getCookie, splitCookiesString, appendResponseHeader } from 'h3'
 import type { Ref } from 'vue'
-import type { ResponseOK, AuthenticationData, Session } from '../types/common'
+import type { ResponseOK, AuthenticationData, SessionOld } from '../types/common'
 import type { PublicConfig, PrivateConfig } from '../types/config'
 import { useAuthToken } from './useAuthToken'
 import { useRequestEvent, useRuntimeConfig, useState, useRequestHeaders, useNuxtApp, useAuth } from '#imports'
@@ -112,10 +112,10 @@ export function useAuthSession() {
   /**
    * Revokes a single stored session of the active user.
    *
-   * @param {Session['id']} id - The ID of the session to revoke.
+   * @param {SessionOld['id']} id - The ID of the session to revoke.
    * @return {Promise<ResponseOK>} A promise that resolves with a ResponseOK object upon successful revocation of the session.
    */
-  function revokeSession(id: Session['id']): Promise<ResponseOK> {
+  function revokeSession(id: SessionOld['id']): Promise<ResponseOK> {
     return useNuxtApp().$auth.fetch<ResponseOK>(`/api/auth/sessions/${id}`, {
       method: 'DELETE',
     })
@@ -124,10 +124,10 @@ export function useAuthSession() {
   /**
    * Retrieves information about all active sessions, offering insights into the user's session history.
    *
-   * @return {Promise<Session[]>} A promise that resolves with an array of Session objects representing all active sessions. The current session is moved to the top of the array.
+   * @return {Promise<SessionOld[]>} A promise that resolves with an array of SessionOld objects representing all active sessions. The current session is moved to the top of the array.
    */
-  async function getAllSessions(): Promise<Session[]> {
-    const sessions = await useNuxtApp().$auth.fetch<Session[]>('/api/auth/sessions')
+  async function getAllSessions(): Promise<SessionOld[]> {
+    const sessions = await useNuxtApp().$auth.fetch<SessionOld[]>('/api/auth/sessions')
 
     // Move current session on top
     const currentIndex = sessions.findIndex(el => el.current)

--- a/src/runtime/server/api/logout.post.ts
+++ b/src/runtime/server/api/logout.post.ts
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
 
     const payload = await verifyRefreshToken(event, refreshToken)
 
-    await event.context.auth.adapter.refreshToken.delete(payload.id, payload.userId)
+    await event.context.auth.adapter.session.delete(payload.id, payload.userId)
 
     deleteRefreshTokenCookie(event)
 

--- a/src/runtime/server/api/password/change.put.ts
+++ b/src/runtime/server/api/password/change.put.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
       password: hashedPassword,
     })
 
-    await event.context.auth.adapter.refreshToken.deleteManyByUserId(authData.userId, authData.sessionId)
+    await event.context.auth.adapter.session.deleteManyByUserId(authData.userId, authData.sessionId)
 
     return { status: 'ok' }
   }

--- a/src/runtime/server/api/password/reset.put.ts
+++ b/src/runtime/server/api/password/reset.put.ts
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
       password: hashedPassword,
     })
 
-    await event.context.auth.adapter.refreshToken.deleteManyByUserId(payload.userId)
+    await event.context.auth.adapter.session.deleteManyByUserId(payload.userId)
 
     await event.context.auth.adapter.user.update(payload.userId, { requestedPasswordReset: false })
 

--- a/src/runtime/server/api/sessions/[id].delete.ts
+++ b/src/runtime/server/api/sessions/[id].delete.ts
@@ -19,13 +19,13 @@ export default defineEventHandler(async (event) => {
     // @ts-expect-error id can either be string or number
     params.id = Number.isNaN(Number(params.id)) ? params.id : Number(params.id)
 
-    const refreshTokenEntity = await event.context.auth.adapter.refreshToken.findById(params.id, authData.userId)
+    const session = await event.context.auth.adapter.session.findById(params.id, authData.userId)
 
-    if (refreshTokenEntity?.userId !== authData.userId) {
+    if (session?.userId !== authData.userId) {
       throw createUnauthorizedError()
     }
 
-    await event.context.auth.adapter.refreshToken.delete(params.id, authData.userId)
+    await event.context.auth.adapter.session.delete(params.id, authData.userId)
 
     return { status: 'ok' }
   }

--- a/src/runtime/server/api/sessions/index.delete.ts
+++ b/src/runtime/server/api/sessions/index.delete.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
       throw createUnauthorizedError()
     }
 
-    await event.context.auth.adapter.refreshToken.deleteManyByUserId(authData.userId, authData.sessionId)
+    await event.context.auth.adapter.session.deleteManyByUserId(authData.userId, authData.sessionId)
 
     return { status: 'ok' }
   }

--- a/src/runtime/server/api/sessions/index.get.ts
+++ b/src/runtime/server/api/sessions/index.get.ts
@@ -1,6 +1,5 @@
 import { defineEventHandler } from 'h3'
 import { handleError, createUnauthorizedError } from '../../utils'
-import type { SessionOld } from '../../../types/common'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -12,13 +11,10 @@ export default defineEventHandler(async (event) => {
 
     const sessions = await event.context.auth.adapter.session.findManyByUserId(authData.userId)
 
-    return sessions.map<SessionOld>(session => ({
-      id: session.id,
-      current: session.id === authData.sessionId,
-      ua: session.userAgent,
-      createdAt: session.createdAt,
-      updatedAt: session.updatedAt,
-    }))
+    return {
+      active: sessions,
+      current: sessions.find(session => session.id === authData.sessionId),
+    }
   }
   catch (error) {
     await handleError(error)

--- a/src/runtime/server/api/sessions/index.get.ts
+++ b/src/runtime/server/api/sessions/index.get.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler } from 'h3'
 import { handleError, createUnauthorizedError } from '../../utils'
-import type { Session } from '../../../types/common'
+import type { SessionOld } from '../../../types/common'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -10,14 +10,14 @@ export default defineEventHandler(async (event) => {
       throw createUnauthorizedError()
     }
 
-    const refreshTokens = await event.context.auth.adapter.refreshToken.findManyByUserId(authData.userId)
+    const sessions = await event.context.auth.adapter.session.findManyByUserId(authData.userId)
 
-    return refreshTokens.map<Session>(token => ({
-      id: token.id,
-      current: token.id === authData.sessionId,
-      ua: token.userAgent,
-      createdAt: token.createdAt,
-      updatedAt: token.updatedAt,
+    return sessions.map<SessionOld>(session => ({
+      id: session.id,
+      current: session.id === authData.sessionId,
+      ua: session.userAgent,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
     }))
   }
   catch (error) {

--- a/src/runtime/server/utils/adapter/prisma.ts
+++ b/src/runtime/server/utils/adapter/prisma.ts
@@ -44,9 +44,9 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       },
     },
 
-    refreshToken: {
+    session: {
       async findById(id, userId) {
-        return prisma.refreshToken.findUnique({
+        return prisma.session.findUnique({
           where: {
             id,
             userId,
@@ -55,7 +55,7 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       },
 
       async findManyByUserId(userId) {
-        return prisma.refreshToken.findMany({
+        return prisma.session.findMany({
           where: {
             userId,
           },
@@ -63,7 +63,7 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       },
 
       async create(data) {
-        return prisma.refreshToken.create({
+        return prisma.session.create({
           data: {
             ...data,
             userId: data.userId,
@@ -75,7 +75,7 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       },
 
       async update(id, data) {
-        await prisma.refreshToken.update({
+        await prisma.session.update({
           where: {
             id,
           },
@@ -89,7 +89,7 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       },
 
       async delete(id, userId) {
-        await prisma.refreshToken.delete({
+        await prisma.session.delete({
           where: {
             id,
             userId,
@@ -101,7 +101,7 @@ export const definePrismaAdapter = defineAdapter<PrismaClient>((prisma) => {
       },
 
       async deleteManyByUserId(userId, excludeId) {
-        await prisma.refreshToken.deleteMany({
+        await prisma.session.deleteMany({
           where: {
             userId,
             id: {

--- a/src/runtime/server/utils/adapter/unstorage.ts
+++ b/src/runtime/server/utils/adapter/unstorage.ts
@@ -1,7 +1,7 @@
 import type { Storage } from 'unstorage'
 import { randomUUID } from 'uncrypto'
 import { defineAdapter } from './utils'
-import type { User, RefreshToken } from '#auth_adapter'
+import type { User, Session } from '#auth_adapter'
 
 export const defineUnstorageAdapter = defineAdapter<Storage>((storage) => {
   if (!storage) {
@@ -44,14 +44,14 @@ export const defineUnstorageAdapter = defineAdapter<Storage>((storage) => {
       },
     },
 
-    refreshToken: {
+    session: {
       async findById(id, userId) {
-        return storage.getItem<RefreshToken>(`users:id:${userId}:tokens:${id}`)
+        return storage.getItem<Session>(`users:id:${userId}:tokens:${id}`)
       },
 
       async findManyByUserId(userId) {
         const tokens = await storage.getKeys(`users:id:${userId}:tokens`).then((keys) => {
-          return storage.getItems<RefreshToken>(keys)
+          return storage.getItems<Session>(keys)
         })
         return tokens.map(token => token.value)
       },

--- a/src/runtime/server/utils/token/accessToken.ts
+++ b/src/runtime/server/utils/token/accessToken.ts
@@ -2,12 +2,12 @@ import { getRequestHeader } from 'h3'
 import type { H3Event } from 'h3'
 import { getConfig } from '../config'
 import { mustache } from '../mustache'
-import type { SessionOld, AccessTokenPayload } from '../../../types/common'
+import type { AccessTokenPayload } from '../../../types/common'
 import { encode, decode } from './jwt'
 import { getFingerprintHash, verifyFingerprint } from './fingerprint'
-import type { User } from '#auth_adapter'
+import type { User, Session } from '#auth_adapter'
 
-export async function createAccessToken(event: H3Event, user: User, sessionId: SessionOld['id']) {
+export async function createAccessToken(event: H3Event, user: User, sessionId: Session['id']) {
   const config = getConfig()
 
   let customClaims = {}

--- a/src/runtime/server/utils/token/accessToken.ts
+++ b/src/runtime/server/utils/token/accessToken.ts
@@ -2,12 +2,12 @@ import { getRequestHeader } from 'h3'
 import type { H3Event } from 'h3'
 import { getConfig } from '../config'
 import { mustache } from '../mustache'
-import type { Session, AccessTokenPayload } from '../../../types/common'
+import type { SessionOld, AccessTokenPayload } from '../../../types/common'
 import { encode, decode } from './jwt'
 import { getFingerprintHash, verifyFingerprint } from './fingerprint'
 import type { User } from '#auth_adapter'
 
-export async function createAccessToken(event: H3Event, user: User, sessionId: Session['id']) {
+export async function createAccessToken(event: H3Event, user: User, sessionId: SessionOld['id']) {
   const config = getConfig()
 
   let customClaims = {}

--- a/src/runtime/types/adapter.d.ts
+++ b/src/runtime/types/adapter.d.ts
@@ -18,8 +18,8 @@ export interface User {
   requestedPasswordReset?: boolean | null
 }
 
-export interface RefreshToken {
-  id: NumberOrString<RefreshTokenId>
+export interface Session {
+  id: NumberOrString<SessionId>
   uid: string
   userAgent: string | null
   createdAt: Date
@@ -30,9 +30,9 @@ export interface RefreshToken {
 type UserCreateInput = Pick<User, 'name' | 'email' | 'password' | 'picture' | 'provider' | 'role' | 'verified'>
 type UserCreateOutput = User
 type UserUpdateInput = Omit<Partial<User>, 'id'>
-type RefreshTokenCreateInput = Pick<RefreshToken, 'uid' | 'userAgent' | 'userId'>
-type RefreshTokenCreateOutput = Pick<RefreshToken, 'id'>
-type RefreshTokenUpdateInput = Pick<RefreshToken, 'uid' | 'userId'>
+type SessionCreateInput = Pick<Session, 'uid' | 'userAgent' | 'userId'>
+type SessionCreateOutput = Pick<Session, 'id'>
+type SessionUpdateInput = Pick<Session, 'uid' | 'userId'>
 
 export interface Adapter<SourceT = Source> {
   name: string
@@ -43,12 +43,12 @@ export interface Adapter<SourceT = Source> {
     create: (input: UserCreateInput) => Promise<UserCreateOutput>
     update: (id: User['id'], input: UserUpdateInput) => Promise<void>
   }
-  refreshToken: {
-    findById: (id: RefreshToken['id'], userId: User['id']) => Promise<RefreshToken | null>
-    findManyByUserId: (id: User['id']) => Promise<RefreshToken[]>
-    create: (input: RefreshTokenCreateInput) => Promise<RefreshTokenCreateOutput>
-    update: (id: RefreshToken['id'], input: RefreshTokenUpdateInput) => Promise<void>
-    delete: (id: RefreshToken['id'], userId: User['id']) => Promise<void>
-    deleteManyByUserId: (userId: User['id'], excludeId?: RefreshToken['id']) => Promise<void>
+  session: {
+    findById: (id: Session['id'], userId: User['id']) => Promise<Session | null>
+    findManyByUserId: (id: User['id']) => Promise<Session[]>
+    create: (input: SessionCreateInput) => Promise<SessionCreateOutput>
+    update: (id: Session['id'], input: SessionUpdateInput) => Promise<void>
+    delete: (id: Session['id'], userId: User['id']) => Promise<void>
+    deleteManyByUserId: (userId: User['id'], excludeId?: Session['id']) => Promise<void>
   }
 }

--- a/src/runtime/types/common.d.ts
+++ b/src/runtime/types/common.d.ts
@@ -2,14 +2,6 @@ import type { FetchError } from 'ofetch'
 import type { H3Error } from 'h3'
 import type { Adapter, User, Session } from '#auth_adapter'
 
-export interface SessionOld {
-  current: boolean
-  id: RefreshToken['id']
-  ua: RefreshToken['userAgent']
-  updatedAt: RefreshToken['updatedAt']
-  createdAt: RefreshToken['createdAt']
-}
-
 export type AccessTokenPayload = {
   fingerprint: string | null
   userId: User['id']

--- a/src/runtime/types/common.d.ts
+++ b/src/runtime/types/common.d.ts
@@ -1,8 +1,8 @@
 import type { FetchError } from 'ofetch'
 import type { H3Error } from 'h3'
-import type { Adapter, RefreshToken, User } from '#auth_adapter'
+import type { Adapter, User, Session } from '#auth_adapter'
 
-export interface Session {
+export interface SessionOld {
   current: boolean
   id: RefreshToken['id']
   ua: RefreshToken['userAgent']
@@ -13,7 +13,7 @@ export interface Session {
 export type AccessTokenPayload = {
   fingerprint: string | null
   userId: User['id']
-  sessionId: RefreshToken['id']
+  sessionId: Session['id']
   userRole: User['role']
   provider: User['provider']
   verified: User['verified']


### PR DESCRIPTION
This PR introduces 3 changes:
- To avoid ambiguity, the `RefreshToken` data model is renamed to `Session`.

```ts
interface Session {
  id: string
  uid: string
  userAgent: string | null
  createdAt: Date
  updatedAt: Date
  userId: string
}
```
- This only affects Frontend-only usage, the response of the endpoint [GET]  /api/auth/sessions is changed:

```diff
-interface Response {
-     id: string
-     current: boolean
-     ua: string | null
-     createdAt: Date
-     updatedAt: Date
-}

+interface Response {
+    active: Session[]
+    current?: Session
+}
```
-The return value of `getAllSessions` is changed:

```diff
-Promise<Array<{
-  id: string
-  current: boolean
-  ua: string | null
-  updatedAt: Date
-  createdAt: Date
-}>>

+Promise<Array<Session & { current: boolean }>>
```
  