### PR TITLE
fix: solve potential infinite redirections on Vercel

### DIFF
--- a/src/runtime/composables/useAuth.ts
+++ b/src/runtime/composables/useAuth.ts
@@ -121,7 +121,8 @@ export function useAuth() {
       return
     }
     const returnToPath = useRoute().query.redirect?.toString()
-    const redirectTo = returnToPath ?? publicConfig.redirect.home
+    const decodedReturnToPath = returnToPath && decodeURIComponent(returnToPath)
+    const redirectTo = decodedReturnToPath ?? publicConfig.redirect.home
     await callHook('auth:loggedIn', true)
     await navigateTo(redirectTo)
   }

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -20,9 +20,12 @@ export default defineNuxtRouteMiddleware((to) => {
   }
 
   if (!useAuthToken().value) {
+    const returnToPath = to.path
+    const encodedReturnToPath = returnToPath && encodeURIComponent(returnToPath)
+
     return navigateTo({
       path: publicConfig.redirect.login,
-      query: { redirect: to.path },
+      query: { redirect: encodedReturnToPath },
     })
   }
 })

--- a/src/runtime/middleware/common.ts
+++ b/src/runtime/middleware/common.ts
@@ -11,7 +11,8 @@ export default defineNuxtRouteMiddleware((to, from) => {
   ) {
     if (useAuthToken().value) {
       const returnToPath = from.query.redirect?.toString()
-      const redirectTo = returnToPath ?? publicConfig.redirect.home
+      const decodedReturnToPath = returnToPath && decodeURIComponent(returnToPath)
+      const redirectTo = decodedReturnToPath ?? publicConfig.redirect.home
       return navigateTo(redirectTo)
     }
   }

--- a/src/runtime/server/api/login/[provider].get.ts
+++ b/src/runtime/server/api/login/[provider].get.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   const { provider } = await getValidatedRouterParams(event, pSchema.parse)
 
   const qSchema = z.object({
-    redirect: z.string().startsWith('/').optional(),
+    redirect: z.string().startsWith('%2F').optional(),
   })
 
   // The protected page the user has visited before redirect to login page

--- a/src/runtime/server/api/login/[provider]/callback.get.ts
+++ b/src/runtime/server/api/login/[provider]/callback.get.ts
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
 
     const qSchema = z.object({
       code: z.string().min(1),
-      state: z.string().startsWith('/').optional(),
+      state: z.string().startsWith('%2F').optional(),
     })
 
     const { state: returnToPath, code } = await getValidatedQuery(event, qSchema.parse)


### PR DESCRIPTION
The `redirect` query parameter used to return to the previously visited page on login needs to be encoded to avoid infinite redirections on Vercel.